### PR TITLE
請求一覧画面と処理画面（一部）を作成した。

### DIFF
--- a/front/src/components/manage/list/List.tsx
+++ b/front/src/components/manage/list/List.tsx
@@ -4,11 +4,12 @@ import { Process } from "./Process";
 
 export const List = () => {
     const [step, setStep] = useState<number>(0);
+    const [userId, setUserID] = useState<string>("test1");
 
     if (step === 0) {
-        return <Select />
+        return <Select step={step} setStep={setStep} userId={userId} setUserId={setUserID} />
     } else if (step === 1) {
-        return <Process />
+        return <Process step={step} setStep={setStep} userId={userId} />
     } else {
         return(
             <h1>ステップが無効です。</h1>

--- a/front/src/components/manage/list/List.tsx
+++ b/front/src/components/manage/list/List.tsx
@@ -1,7 +1,17 @@
+import { useState } from "react"
+import { Select } from "./Select";
+import { Process } from "./Process";
+
 export const List = () => {
-    return (
-        <div className="historyContentsArea">
-            <h1>請求一覧</h1>
-        </div>
-    )
+    const [step, setStep] = useState<number>(0);
+
+    if (step === 0) {
+        return <Select />
+    } else if (step === 1) {
+        return <Process />
+    } else {
+        return(
+            <h1>ステップが無効です。</h1>
+        )
+    }
 }

--- a/front/src/components/manage/list/Process.tsx
+++ b/front/src/components/manage/list/Process.tsx
@@ -1,5 +1,17 @@
-export const Process = () => {
+type Props = {
+    step: number;
+    setStep: React.Dispatch<React.SetStateAction<number>>;
+    userId: string;
+}
+
+export const Process = (props: Props) => {
+    const setStep = props.setStep;
+    const userId = props.userId;
     return (
-        <h1>プロセス</h1>
+        <>
+            <h1>プロセス</h1>
+            <p>表示するユーザ：{userId}</p>
+            <button onClick={() =>  setStep(0)}>選択に戻る</button>
+        </>
     )
 }

--- a/front/src/components/manage/list/Process.tsx
+++ b/front/src/components/manage/list/Process.tsx
@@ -1,0 +1,5 @@
+export const Process = () => {
+    return (
+        <h1>プロセス</h1>
+    )
+}

--- a/front/src/components/manage/list/Select.tsx
+++ b/front/src/components/manage/list/Select.tsx
@@ -1,0 +1,5 @@
+export const Select = () => {
+    return (
+        <h1>選択</h1>
+    )
+}

--- a/front/src/components/manage/list/Select.tsx
+++ b/front/src/components/manage/list/Select.tsx
@@ -1,5 +1,48 @@
+import { Container, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from "@mui/material"
+
+interface BillListData {
+    no: number;
+    userId: string;
+    name: string;
+    finalPrice: number;
+    paid: number;
+}
+
 export const Select = () => {
+    const listData: BillListData[] = [
+        {no: 0, userId: "test1", name: "山田 太郎", finalPrice: 3500, paid: 0},
+        {no: 1, userId: "test2", name: "鈴木太郎", finalPrice: 4000, paid: 1}
+    ];
+
     return (
-        <h1>選択</h1>
+        <Container sx={{width: "90%", marginTop: "30px"}}>
+            <TableContainer component={Paper}>
+        <Table sx={{ minWidth: 500}} aria-label="simple table">
+          <TableHead>
+            <TableRow>
+              <TableCell align="center">部屋No.</TableCell>
+              <TableCell sx={{ minWidth: 150 }} align="center">氏名</TableCell>
+              <TableCell align="right">請求予定額</TableCell>
+              <TableCell align="right">チェック</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {listData.map((data) => (
+              <TableRow
+                key={data.no}
+                sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+              >
+                <TableCell component="th" scope="row" align="center">
+                  {data.no}
+                </TableCell>
+                <TableCell sx={{ minWidth: 150 }} align="center">{data.name}</TableCell>
+                <TableCell align="right">￥{data.finalPrice}</TableCell>
+                <TableCell align="right">チェック</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+        </Container>
     )
 }

--- a/front/src/components/manage/list/Select.tsx
+++ b/front/src/components/manage/list/Select.tsx
@@ -1,5 +1,12 @@
 import { Container, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from "@mui/material"
 
+type Props = {
+    step: number;
+    setStep: React.Dispatch<React.SetStateAction<number>>;
+    userId: string;
+    setUserId: React.Dispatch<React.SetStateAction<string>>;
+}
+
 interface BillListData {
     no: number;
     userId: string;
@@ -8,7 +15,10 @@ interface BillListData {
     paid: number;
 }
 
-export const Select = () => {
+export const Select = (props: Props) => {
+    const setStep = props.setStep;
+    const setUserId = props.setUserId;
+
     const listData: BillListData[] = [
         {no: 0, userId: "test1", name: "山田 太郎", finalPrice: 3500, paid: 0},
         {no: 1, userId: "test2", name: "鈴木太郎", finalPrice: 4000, paid: 1}
@@ -29,6 +39,7 @@ export const Select = () => {
           <TableBody>
             {listData.map((data) => (
               <TableRow
+                onClick={() => {setUserId(data.userId); setStep(1);}}
                 key={data.no}
                 sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
               >

--- a/front/src/components/manage/list/Select.tsx
+++ b/front/src/components/manage/list/Select.tsx
@@ -1,4 +1,7 @@
 import { Container, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from "@mui/material"
+import CheckIcon from '@mui/icons-material/Check';
+import ChangeCircleIcon from '@mui/icons-material/ChangeCircle';
+import HorizontalRuleIcon from '@mui/icons-material/HorizontalRule';
 
 type Props = {
     step: number;
@@ -20,8 +23,9 @@ export const Select = (props: Props) => {
     const setUserId = props.setUserId;
 
     const listData: BillListData[] = [
-        {no: 0, userId: "test1", name: "山田 太郎", finalPrice: 3500, paid: 0},
-        {no: 1, userId: "test2", name: "鈴木太郎", finalPrice: 4000, paid: 1}
+        {no: 1, userId: "test1", name: "山田 太郎", finalPrice: 3500, paid: 0},
+        {no: 2, userId: "test2", name: "鈴木 太郎", finalPrice: 4000, paid: 1},
+        {no: 3, userId: "test3", name: "高橋 太郎", finalPrice: 3500, paid: 2},
     ];
 
     return (
@@ -42,13 +46,32 @@ export const Select = (props: Props) => {
                 onClick={() => {setUserId(data.userId); setStep(1);}}
                 key={data.no}
                 sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+                style={{cursor: "pointer"}}
               >
                 <TableCell component="th" scope="row" align="center">
                   {data.no}
                 </TableCell>
                 <TableCell sx={{ minWidth: 150 }} align="center">{data.name}</TableCell>
                 <TableCell align="right">￥{data.finalPrice}</TableCell>
-                <TableCell align="right">チェック</TableCell>
+                {(() => {
+                if (data.paid === 0) {
+                    return (
+                        <TableCell align="right"><HorizontalRuleIcon /></TableCell>
+                    )
+                } else if (data.paid === 1) {
+                    return (
+                        <TableCell align="right"><CheckIcon /></TableCell>
+                    )
+                } else if (data.paid === 2) {
+                    return (
+                        <TableCell align="right"><ChangeCircleIcon /></TableCell>
+                    )
+                } else {
+                    return (
+                        <TableCell align="right"></TableCell>
+                    )
+                }
+            })()}
               </TableRow>
             ))}
           </TableBody>


### PR DESCRIPTION
# 変更
* 請求一覧画面の表示にテーブルを使用して配置した。
* テーブルの行をクリックすると、そのuserIdの請求処理画面へ飛べるようにした。
* 処理画面へ飛んだ時には、請求一覧画面を非表示にするようにした。

# issue
#20 