### PR TITLE
請求一覧と請求処理画面を作成した。

### DIFF
--- a/front/src/components/manage/list/List.tsx
+++ b/front/src/components/manage/list/List.tsx
@@ -5,11 +5,12 @@ import { Process } from "./Process";
 export const List = () => {
     const [step, setStep] = useState<number>(0);
     const [userId, setUserID] = useState<string>("test1");
+    const [userName, setUserName] = useState<string>("田中 太郎");
 
     if (step === 0) {
-        return <Select step={step} setStep={setStep} userId={userId} setUserId={setUserID} />
+        return <Select step={step} setStep={setStep} userId={userId} setUserId={setUserID} setUserName={setUserName} />
     } else if (step === 1) {
-        return <Process step={step} setStep={setStep} userId={userId} />
+        return <Process step={step} setStep={setStep} userId={userId} userName={userName}  />
     } else {
         return(
             <h1>ステップが無効です。</h1>

--- a/front/src/components/manage/list/Process.tsx
+++ b/front/src/components/manage/list/Process.tsx
@@ -1,5 +1,5 @@
 import { KeyboardArrowLeft, KeyboardArrowRight } from "@mui/icons-material";
-import { Button, Container, MobileStepper, Paper, Stack, Typography, useTheme } from "@mui/material";
+import { Button, Container, MobileStepper, Paper, Stack, Tab, Tabs, Typography, useTheme } from "@mui/material";
 import { useState } from "react";
 import { Process1 } from "./Process1";
 import { Process2 } from "./Process2";
@@ -26,43 +26,11 @@ export const Process = (props: Props) => {
     //請求データを格納する
     const [billingData, setBillingData] = useState<BillingData>({billingId: "test01", userId: "kait", useAmount: 350, price: 3000, beforeCarryOver: 0, carryOverType: "no", carryOverPrice: 0, finalPrice: 3000, dateId: 0, paid: 0});
 
-    return (
-        <Container sx={{width: "90%", height: "100%"}}>
-            <Typography variant="h5">請求処理</Typography>
-            <button onClick={() =>  setStep(0)}>選択に戻る</button>
+    const [tabValue, setTabValue] = useState<string>("0");
 
-            <Paper elevation={3} sx={{width: "80%", margin: "0 auto"}} children={
-                <Container sx={{width: "80%", height: "150px"}}>
-                    <Stack spacing={0.5} sx={{paddingTop: "20px", textAlign: "center"}}>
-                        <Typography variant='h6'>8月12日 {userName}</Typography>
-                        <Typography variant='h4'>￥{billingData.finalPrice}</Typography>
-                        <hr />
-                        <Typography variant='body1'>支払い予定額  ￥1,500</Typography>
-                    </Stack>
-                </Container>
-            } />
-
-            {(() => {
-                if (stepperStep === 0) {
-                    return (
-                        <Process1 billingData={billingData} setBillingData={setBillingData} />
-                    )
-                } else if (stepperStep === 1) {
-                    return (
-                        <Process2 billingData={billingData} setBillingData={setBillingData} />
-                    )
-                } else if (stepperStep === 2) {
-                    return (
-                        <Process3 billingData={billingData} setBillingData={setBillingData} />
-                    )
-                } else {
-                    return (
-                        <h1>範囲外のステップです。</h1>
-                    )
-                }
-            })()}
-
-            <MobileStepper
+    const Step = () => {
+      return (
+        <MobileStepper
         variant="text"
         steps={maxSteps}
         position="static"
@@ -92,6 +60,77 @@ export const Process = (props: Props) => {
           </Button>
         }
       />
+      )
+    }
+
+    return (
+        <Container sx={{width: "90%", height: "100%"}}>
+            <button onClick={() =>  setStep(0)}>選択に戻る</button>
+
+            <Container sx={{width: "80%"}}>
+            <Tabs
+                value={tabValue}
+                onChange={(event: React.BaseSyntheticEvent, newValue: string) => setTabValue(newValue) }
+                textColor="primary"
+                indicatorColor="primary"
+                aria-label="secondary tabs example"
+            >
+                <Tab value="0" label="確認" />
+                <Tab value="1" label="集金" />
+                <Tab value="2" label="チャット" />
+            </Tabs>
+            </Container>
+
+            <Paper elevation={3} sx={{width: "80%", margin: "0 auto"}} children={
+                <Container sx={{width: "80%", height: "150px"}}>
+                    <Stack spacing={0.5} sx={{paddingTop: "20px", textAlign: "center"}}>
+                        <Typography variant='h6'>8月12日 {userName}</Typography>
+                        <Typography variant='h4'>￥{billingData.finalPrice}</Typography>
+                        <hr />
+                        <Typography variant='body1'>支払い予定額  ￥1,500</Typography>
+                    </Stack>
+                </Container>
+            } />
+
+            {(() => {
+                if (tabValue === "0") {
+                  return (
+                    <h1>確認タブ</h1>
+                  )
+                } else if (tabValue === "1") {
+                  if (stepperStep === 0) {
+                    return (
+                      <>
+                         <Process1 billingData={billingData} setBillingData={setBillingData} />
+                        <Step />
+                      </>
+                    )
+                  } else if (stepperStep === 1) {
+                    return (
+                      <>
+                        <Process2 billingData={billingData} setBillingData={setBillingData} />
+                         <Step />
+                      </>
+                    )
+                  } else if (stepperStep === 2) {
+                    return (
+                      <>
+                        <Process3 billingData={billingData} setBillingData={setBillingData} />
+                        <Step />
+                      </>
+                    )
+                  } else {
+                    return (
+                        <h1>範囲外のステップです。</h1>
+                    )
+                  }
+                } else {
+                  return (
+                    <h1>チャットタブ</h1>
+                  )
+                }
+            })()}
+
         </Container>
     )
 }

--- a/front/src/components/manage/list/Process.tsx
+++ b/front/src/components/manage/list/Process.tsx
@@ -1,5 +1,5 @@
 import { KeyboardArrowLeft, KeyboardArrowRight } from "@mui/icons-material";
-import { Button, MobileStepper, useTheme } from "@mui/material";
+import { Button, Container, MobileStepper, useTheme } from "@mui/material";
 import { useState } from "react";
 
 type Props = {
@@ -17,9 +17,9 @@ export const Process = (props: Props) => {
     const theme = useTheme();
 
     return (
-        <>
-            <h1>プロセス</h1>
-            <p>表示するユーザ：{userId}</p>
+        <Container sx={{width: "90%"}}>
+            <h1>請求処理</h1>
+            <p>処理するユーザ：{userId}</p>
             <button onClick={() =>  setStep(0)}>選択に戻る</button>
 
             <MobileStepper
@@ -33,7 +33,7 @@ export const Process = (props: Props) => {
             onClick={() => setStepperStep(stepperStep + 1)}
             disabled={stepperStep === maxSteps - 1}
           >
-            Next
+            次へ
             {theme.direction === 'rtl' ? (
               <KeyboardArrowLeft />
             ) : (
@@ -48,10 +48,10 @@ export const Process = (props: Props) => {
             ) : (
               <KeyboardArrowLeft />
             )}
-            Back
+            戻る
           </Button>
         }
       />
-        </>
+        </Container>
     )
 }

--- a/front/src/components/manage/list/Process.tsx
+++ b/front/src/components/manage/list/Process.tsx
@@ -58,7 +58,7 @@ export const Process = (props: Props) => {
                     )
                   } else if (stepperStep === 2) {
                     return (
-                        <Process3 billingData={billingData} setBillingData={setBillingData} />
+                        <Process3 billingData={billingData} setBillingData={setBillingData} step={step} setStep={setStep} userName={userName} />
                     )
                   } else {
                     return (

--- a/front/src/components/manage/list/Process.tsx
+++ b/front/src/components/manage/list/Process.tsx
@@ -1,12 +1,16 @@
 import { KeyboardArrowLeft, KeyboardArrowRight } from "@mui/icons-material";
 import { Button, Container, MobileStepper, useTheme } from "@mui/material";
 import { useState } from "react";
+import { Process1 } from "./Process1";
+import { Process2 } from "./Process2";
+import { Process3 } from "./Process3";
 
 type Props = {
     step: number;
     setStep: React.Dispatch<React.SetStateAction<number>>;
     userId: string;
 }
+
 
 export const Process = (props: Props) => {
     const setStep = props.setStep;
@@ -25,15 +29,15 @@ export const Process = (props: Props) => {
             {(() => {
                 if (stepperStep === 0) {
                     return (
-                        <h1>ステップ1</h1>
+                        <Process1 />
                     )
                 } else if (stepperStep === 1) {
                     return (
-                        <h1>ステップ2</h1>
+                        <Process2 />
                     )
                 } else if (stepperStep === 2) {
                     return (
-                        <h1>ステップ3</h1>
+                        <Process3 />
                     )
                 } else {
                     return (

--- a/front/src/components/manage/list/Process.tsx
+++ b/front/src/components/manage/list/Process.tsx
@@ -11,12 +11,14 @@ type Props = {
     step: number;
     setStep: React.Dispatch<React.SetStateAction<number>>;
     userId: string;
+    userName: string;
 }
 
 
 export const Process = (props: Props) => {
     const setStep = props.setStep;
     const userId = props.userId;
+    const userName = props.userName;
 
     const [stepperStep, setStepperStep] = useState<number>(0);
     const maxSteps = 3;
@@ -28,13 +30,12 @@ export const Process = (props: Props) => {
     return (
         <Container sx={{width: "90%", height: "100%"}}>
             <h1>請求処理</h1>
-            <p>処理するユーザ：{userId}</p>
             <button onClick={() =>  setStep(0)}>選択に戻る</button>
 
             <Paper elevation={3} sx={{width: "80%", margin: "0 auto"}} children={
                 <Container sx={{width: "80%", height: "150px"}}>
                     <Stack spacing={0.5} sx={{paddingTop: "20px", textAlign: "center"}}>
-                        <Typography variant='h6'>8月12日 請求金額</Typography>
+                        <Typography variant='h6'>8月12日 {userName}</Typography>
                         <Typography variant='h4'>￥{billingData.finalPrice}</Typography>
                         <hr />
                         <Typography variant='body1'>支払い予定額  ￥1,500</Typography>

--- a/front/src/components/manage/list/Process.tsx
+++ b/front/src/components/manage/list/Process.tsx
@@ -45,15 +45,15 @@ export const Process = (props: Props) => {
             {(() => {
                 if (stepperStep === 0) {
                     return (
-                        <Process1 />
+                        <Process1 billingData={billingData} setBillingData={setBillingData} />
                     )
                 } else if (stepperStep === 1) {
                     return (
-                        <Process2 />
+                        <Process2 billingData={billingData} setBillingData={setBillingData} />
                     )
                 } else if (stepperStep === 2) {
                     return (
-                        <Process3 />
+                        <Process3 billingData={billingData} setBillingData={setBillingData} />
                     )
                 } else {
                     return (

--- a/front/src/components/manage/list/Process.tsx
+++ b/front/src/components/manage/list/Process.tsx
@@ -1,3 +1,7 @@
+import { KeyboardArrowLeft, KeyboardArrowRight } from "@mui/icons-material";
+import { Button, MobileStepper, useTheme } from "@mui/material";
+import { useState } from "react";
+
 type Props = {
     step: number;
     setStep: React.Dispatch<React.SetStateAction<number>>;
@@ -7,11 +11,47 @@ type Props = {
 export const Process = (props: Props) => {
     const setStep = props.setStep;
     const userId = props.userId;
+
+    const [stepperStep, setStepperStep] = useState<number>(0);
+    const maxSteps = 3;
+    const theme = useTheme();
+
     return (
         <>
             <h1>プロセス</h1>
             <p>表示するユーザ：{userId}</p>
             <button onClick={() =>  setStep(0)}>選択に戻る</button>
+
+            <MobileStepper
+        variant="text"
+        steps={maxSteps}
+        position="static"
+        activeStep={stepperStep}
+        nextButton={
+          <Button
+            size="small"
+            onClick={() => setStepperStep(stepperStep + 1)}
+            disabled={stepperStep === maxSteps - 1}
+          >
+            Next
+            {theme.direction === 'rtl' ? (
+              <KeyboardArrowLeft />
+            ) : (
+              <KeyboardArrowRight />
+            )}
+          </Button>
+        }
+        backButton={
+          <Button size="small" onClick={() => setStepperStep(stepperStep - 1)} disabled={stepperStep === 0}>
+            {theme.direction === 'rtl' ? (
+              <KeyboardArrowRight />
+            ) : (
+              <KeyboardArrowLeft />
+            )}
+            Back
+          </Button>
+        }
+      />
         </>
     )
 }

--- a/front/src/components/manage/list/Process.tsx
+++ b/front/src/components/manage/list/Process.tsx
@@ -1,5 +1,4 @@
-import { KeyboardArrowLeft, KeyboardArrowRight } from "@mui/icons-material";
-import { Button, Container, MobileStepper, Paper, Stack, Tab, Tabs, Typography, useTheme } from "@mui/material";
+import { Container, Paper, Stack, Tab, Tabs, Typography } from "@mui/material";
 import { useState } from "react";
 import { Process1 } from "./Process1";
 import { Process2 } from "./Process2";

--- a/front/src/components/manage/list/Process.tsx
+++ b/front/src/components/manage/list/Process.tsx
@@ -54,11 +54,11 @@ export const Process = (props: Props) => {
                     )
                   } else if (stepperStep === 1) {
                     return (
-                        <Process2 billingData={billingData} setBillingData={setBillingData} stepperStep={stepperStep} setStepperStep={setStepperStep} userName={userName} />
+                        <Process2 billingData={billingData} stepperStep={stepperStep} setStepperStep={setStepperStep} userName={userName} />
                     )
                   } else if (stepperStep === 2) {
                     return (
-                        <Process3 billingData={billingData} setBillingData={setBillingData} step={step} setStep={setStep} userName={userName} />
+                        <Process3 billingData={billingData} step={step} setStep={setStep} userName={userName} />
                     )
                   } else {
                     return (

--- a/front/src/components/manage/list/Process.tsx
+++ b/front/src/components/manage/list/Process.tsx
@@ -5,6 +5,8 @@ import { Process1 } from "./Process1";
 import { Process2 } from "./Process2";
 import { Process3 } from "./Process3";
 
+import { BillingData } from "../../types/BillingData";
+
 type Props = {
     step: number;
     setStep: React.Dispatch<React.SetStateAction<number>>;
@@ -19,6 +21,9 @@ export const Process = (props: Props) => {
     const [stepperStep, setStepperStep] = useState<number>(0);
     const maxSteps = 3;
     const theme = useTheme();
+
+    //請求データを格納する
+    const [billingData, setBillingData] = useState<BillingData>({billingId: "test01", userId: "kait", useAmount: 350, price: 3000, beforeCarryOver: 0, carryOverType: "no", carryOverPrice: 0, finalPrice: 3000, dateId: 0, paid: 0});
 
     return (
         <Container sx={{width: "90%", height: "100%"}}>

--- a/front/src/components/manage/list/Process.tsx
+++ b/front/src/components/manage/list/Process.tsx
@@ -22,6 +22,26 @@ export const Process = (props: Props) => {
             <p>処理するユーザ：{userId}</p>
             <button onClick={() =>  setStep(0)}>選択に戻る</button>
 
+            {(() => {
+                if (stepperStep === 0) {
+                    return (
+                        <h1>ステップ1</h1>
+                    )
+                } else if (stepperStep === 1) {
+                    return (
+                        <h1>ステップ2</h1>
+                    )
+                } else if (stepperStep === 2) {
+                    return (
+                        <h1>ステップ3</h1>
+                    )
+                } else {
+                    return (
+                        <h1>範囲外のステップです。</h1>
+                    )
+                }
+            })()}
+
             <MobileStepper
         variant="text"
         steps={maxSteps}

--- a/front/src/components/manage/list/Process.tsx
+++ b/front/src/components/manage/list/Process.tsx
@@ -24,7 +24,7 @@ export const Process = (props: Props) => {
     //請求データを格納する
     const [billingData, setBillingData] = useState<BillingData>({billingId: "test01", userId: "kait", useAmount: 350, price: 3000, beforeCarryOver: 0, carryOverType: "no", carryOverPrice: 0, finalPrice: 3000, dateId: 0, paid: 0});
 
-    const [tabValue, setTabValue] = useState<string>("0");
+    const [tabValue, setTabValue] = useState<string>("1");
 
     return (
         <Container sx={{width: "90%", height: "100%"}}>

--- a/front/src/components/manage/list/Process.tsx
+++ b/front/src/components/manage/list/Process.tsx
@@ -1,5 +1,5 @@
 import { KeyboardArrowLeft, KeyboardArrowRight } from "@mui/icons-material";
-import { Button, Container, MobileStepper, useTheme } from "@mui/material";
+import { Button, Container, MobileStepper, Paper, Stack, Typography, useTheme } from "@mui/material";
 import { useState } from "react";
 import { Process1 } from "./Process1";
 import { Process2 } from "./Process2";
@@ -30,6 +30,17 @@ export const Process = (props: Props) => {
             <h1>請求処理</h1>
             <p>処理するユーザ：{userId}</p>
             <button onClick={() =>  setStep(0)}>選択に戻る</button>
+
+            <Paper elevation={3} sx={{width: "80%", margin: "0 auto"}} children={
+                <Container sx={{width: "80%", height: "150px"}}>
+                    <Stack spacing={0.5} sx={{paddingTop: "20px", textAlign: "center"}}>
+                        <Typography variant='h6'>8月12日 請求金額</Typography>
+                        <Typography variant='h4'>￥{billingData.finalPrice}</Typography>
+                        <hr />
+                        <Typography variant='body1'>支払い予定額  ￥1,500</Typography>
+                    </Stack>
+                </Container>
+            } />
 
             {(() => {
                 if (stepperStep === 0) {

--- a/front/src/components/manage/list/Process.tsx
+++ b/front/src/components/manage/list/Process.tsx
@@ -66,7 +66,7 @@ export const Process = (props: Props) => {
                     )
                   } else if (stepperStep === 1) {
                     return (
-                        <Process2 billingData={billingData} setBillingData={setBillingData} />
+                        <Process2 billingData={billingData} setBillingData={setBillingData} stepperStep={stepperStep} setStepperStep={setStepperStep} />
                     )
                   } else if (stepperStep === 2) {
                     return (

--- a/front/src/components/manage/list/Process.tsx
+++ b/front/src/components/manage/list/Process.tsx
@@ -17,7 +17,6 @@ type Props = {
 
 export const Process = (props: Props) => {
     const setStep = props.setStep;
-    const userId = props.userId;
     const userName = props.userName;
 
     const [stepperStep, setStepperStep] = useState<number>(0);

--- a/front/src/components/manage/list/Process.tsx
+++ b/front/src/components/manage/list/Process.tsx
@@ -42,17 +42,6 @@ export const Process = (props: Props) => {
             </Tabs>
             </Container>
 
-            <Paper elevation={3} sx={{width: "80%", margin: "0 auto"}} children={
-                <Container sx={{width: "80%", height: "150px"}}>
-                    <Stack spacing={0.5} sx={{paddingTop: "20px", textAlign: "center"}}>
-                        <Typography variant='h6'>8月12日 {userName}</Typography>
-                        <Typography variant='h4'>￥{billingData.finalPrice}</Typography>
-                        <hr />
-                        <Typography variant='body1'>支払い予定額  ￥1,500</Typography>
-                    </Stack>
-                </Container>
-            } />
-
             {(() => {
                 if (tabValue === "0") {
                   return (
@@ -61,11 +50,11 @@ export const Process = (props: Props) => {
                 } else if (tabValue === "1") {
                   if (stepperStep === 0) {
                     return (
-                         <Process1 billingData={billingData} setBillingData={setBillingData} step={step} setStep={setStep} stepperStep={stepperStep} setStepperStep={setStepperStep} />
+                         <Process1 billingData={billingData} setBillingData={setBillingData} step={step} setStep={setStep} stepperStep={stepperStep} setStepperStep={setStepperStep} userName={userName} />
                     )
                   } else if (stepperStep === 1) {
                     return (
-                        <Process2 billingData={billingData} setBillingData={setBillingData} stepperStep={stepperStep} setStepperStep={setStepperStep} />
+                        <Process2 billingData={billingData} setBillingData={setBillingData} stepperStep={stepperStep} setStepperStep={setStepperStep} userName={userName} />
                     )
                   } else if (stepperStep === 2) {
                     return (

--- a/front/src/components/manage/list/Process.tsx
+++ b/front/src/components/manage/list/Process.tsx
@@ -21,7 +21,7 @@ export const Process = (props: Props) => {
     const theme = useTheme();
 
     return (
-        <Container sx={{width: "90%"}}>
+        <Container sx={{width: "90%", height: "100%"}}>
             <h1>請求処理</h1>
             <p>処理するユーザ：{userId}</p>
             <button onClick={() =>  setStep(0)}>選択に戻る</button>

--- a/front/src/components/manage/list/Process.tsx
+++ b/front/src/components/manage/list/Process.tsx
@@ -28,7 +28,7 @@ export const Process = (props: Props) => {
 
     return (
         <Container sx={{width: "90%", height: "100%"}}>
-            <h1>請求処理</h1>
+            <Typography variant="h5">請求処理</Typography>
             <button onClick={() =>  setStep(0)}>選択に戻る</button>
 
             <Paper elevation={3} sx={{width: "80%", margin: "0 auto"}} children={

--- a/front/src/components/manage/list/Process.tsx
+++ b/front/src/components/manage/list/Process.tsx
@@ -16,57 +16,19 @@ type Props = {
 
 
 export const Process = (props: Props) => {
+    const step = props.step;
     const setStep = props.setStep;
     const userName = props.userName;
 
     const [stepperStep, setStepperStep] = useState<number>(0);
-    const maxSteps = 3;
-    const theme = useTheme();
 
     //請求データを格納する
     const [billingData, setBillingData] = useState<BillingData>({billingId: "test01", userId: "kait", useAmount: 350, price: 3000, beforeCarryOver: 0, carryOverType: "no", carryOverPrice: 0, finalPrice: 3000, dateId: 0, paid: 0});
 
     const [tabValue, setTabValue] = useState<string>("0");
 
-    const Step = () => {
-      return (
-        <MobileStepper
-        variant="text"
-        steps={maxSteps}
-        position="static"
-        activeStep={stepperStep}
-        nextButton={
-          <Button
-            size="small"
-            onClick={() => setStepperStep(stepperStep + 1)}
-            disabled={stepperStep === maxSteps - 1}
-          >
-            次へ
-            {theme.direction === 'rtl' ? (
-              <KeyboardArrowLeft />
-            ) : (
-              <KeyboardArrowRight />
-            )}
-          </Button>
-        }
-        backButton={
-          <Button size="small" onClick={() => setStepperStep(stepperStep - 1)} disabled={stepperStep === 0}>
-            {theme.direction === 'rtl' ? (
-              <KeyboardArrowRight />
-            ) : (
-              <KeyboardArrowLeft />
-            )}
-            戻る
-          </Button>
-        }
-      />
-      )
-    }
-
     return (
         <Container sx={{width: "90%", height: "100%"}}>
-            <button onClick={() =>  setStep(0)}>選択に戻る</button>
-
             <Container sx={{width: "80%"}}>
             <Tabs
                 value={tabValue}
@@ -100,24 +62,15 @@ export const Process = (props: Props) => {
                 } else if (tabValue === "1") {
                   if (stepperStep === 0) {
                     return (
-                      <>
-                         <Process1 billingData={billingData} setBillingData={setBillingData} />
-                        <Step />
-                      </>
+                         <Process1 billingData={billingData} setBillingData={setBillingData} step={step} setStep={setStep} stepperStep={stepperStep} setStepperStep={setStepperStep} />
                     )
                   } else if (stepperStep === 1) {
                     return (
-                      <>
                         <Process2 billingData={billingData} setBillingData={setBillingData} />
-                         <Step />
-                      </>
                     )
                   } else if (stepperStep === 2) {
                     return (
-                      <>
                         <Process3 billingData={billingData} setBillingData={setBillingData} />
-                        <Step />
-                      </>
                     )
                   } else {
                     return (

--- a/front/src/components/manage/list/Process1.tsx
+++ b/front/src/components/manage/list/Process1.tsx
@@ -1,3 +1,10 @@
-export const Process1 = () => {
+import { BillingData } from "../../types/BillingData";
+
+type Props = {
+    billingData: BillingData;
+    setBillingData: React.Dispatch<React.SetStateAction<BillingData>>
+}
+
+export const Process1 = (props: Props) => {
     return (<h1>ステップ1</h1>);
 }

--- a/front/src/components/manage/list/Process1.tsx
+++ b/front/src/components/manage/list/Process1.tsx
@@ -31,6 +31,12 @@ export const Process1 = (props: Props) => {
         setCarryOverPrice((billingData.price + billingData.beforeCarryOver) - paymentPrice)
     }, [paymentPrice]);
 
+    //請求情報更新
+    const upDateBillData = () => {
+        const newBillingData: BillingData = {billingId: "test01", userId: "kait", useAmount: 350, price: 3000, beforeCarryOver: 0, carryOverType: "no", carryOverPrice: carryOverPrice, finalPrice: paymentPrice, dateId: 0, paid: 0};
+        setBillingData(newBillingData);
+    }
+
     return (
             <Container sx={{width: "90%", height: "100%", textAlign: "center"}}>
                 <Stack spacing={1} sx={{marginTop: "20px"}}>
@@ -42,7 +48,7 @@ export const Process1 = (props: Props) => {
                     <Button
                         size="small"
                         variant="contained"
-                        onClick={() => setStepperStep(stepperStep + 1)}
+                        onClick={() => {upDateBillData(); setStepperStep(stepperStep + 1);}}
                     >
                         次へ
                     </Button>

--- a/front/src/components/manage/list/Process1.tsx
+++ b/front/src/components/manage/list/Process1.tsx
@@ -1,4 +1,8 @@
+import { Button, Container, Stack, TextField, Typography } from "@mui/material";
 import { BillingData } from "../../types/BillingData";
+
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import { useEffect, useState } from "react";
 
 type Props = {
     billingData: BillingData;
@@ -6,5 +10,28 @@ type Props = {
 }
 
 export const Process1 = (props: Props) => {
-    return (<h1>ステップ1</h1>);
+    const billingData = props.billingData;
+    const setBillingData = props.setBillingData;
+
+    //一部繰越で、今月支払う金額
+    const [paymentPrice, setPaymentPrice] = useState<number>((billingData.price + billingData.beforeCarryOver) - billingData.carryOverPrice);
+    //今月繰り越す金額
+    const [carryOverPrice, setCarryOverPrice] = useState<number>(billingData.carryOverPrice);
+    
+    //繰越金額の再計算
+    useEffect(() => {
+        setCarryOverPrice((billingData.price + billingData.beforeCarryOver) - paymentPrice)
+    }, [paymentPrice]);
+
+    return (
+            <Container sx={{width: "90%", textAlign: "center"}}>
+                <Stack spacing={1} sx={{marginTop: "20px"}}>
+                    <Typography variant="h6">集金金額を入力</Typography>
+                    <TextField id="user-id" onChange={(event) => setPaymentPrice(Number(event.target.value))} value={paymentPrice} variant="outlined" />
+                    <Typography variant="h3"><ArrowDownwardIcon fontSize="large" /></Typography>
+                    <Typography variant="h6">繰越金額</Typography>
+                    <Typography variant="h3">￥{carryOverPrice}</Typography>
+                </Stack>
+            </Container>
+    );
 }

--- a/front/src/components/manage/list/Process1.tsx
+++ b/front/src/components/manage/list/Process1.tsx
@@ -1,0 +1,3 @@
+export const Process1 = () => {
+    return (<h1>ステップ1</h1>);
+}

--- a/front/src/components/manage/list/Process1.tsx
+++ b/front/src/components/manage/list/Process1.tsx
@@ -7,11 +7,19 @@ import { useEffect, useState } from "react";
 type Props = {
     billingData: BillingData;
     setBillingData: React.Dispatch<React.SetStateAction<BillingData>>
+    step: number;
+    setStep: React.Dispatch<React.SetStateAction<number>>;
+    stepperStep: number;
+    setStepperStep: React.Dispatch<React.SetStateAction<number>>;
 }
 
 export const Process1 = (props: Props) => {
     const billingData = props.billingData;
     const setBillingData = props.setBillingData;
+    const step = props.step;
+    const setStep = props.setStep;
+    const stepperStep = props.stepperStep;
+    const setStepperStep = props.setStepperStep;
 
     //一部繰越で、今月支払う金額
     const [paymentPrice, setPaymentPrice] = useState<number>((billingData.price + billingData.beforeCarryOver) - billingData.carryOverPrice);
@@ -24,13 +32,27 @@ export const Process1 = (props: Props) => {
     }, [paymentPrice]);
 
     return (
-            <Container sx={{width: "90%", textAlign: "center"}}>
+            <Container sx={{width: "90%", height: "100%", textAlign: "center"}}>
                 <Stack spacing={1} sx={{marginTop: "20px"}}>
                     <Typography variant="h6">集金金額を入力</Typography>
                     <TextField id="user-id" onChange={(event) => setPaymentPrice(Number(event.target.value))} value={paymentPrice} variant="outlined" />
                     <Typography variant="h3"><ArrowDownwardIcon fontSize="large" /></Typography>
-                    <Typography variant="h6">繰越金額</Typography>
-                    <Typography variant="h3">￥{carryOverPrice}</Typography>
+                    <Typography variant="h5">繰越金額 ￥{carryOverPrice}</Typography>
+
+                    <Button
+                        size="small"
+                        variant="contained"
+                        onClick={() => setStepperStep(stepperStep + 1)}
+                    >
+                        次へ
+                    </Button>
+                    <Button
+                        size="small"
+                        variant="outlined"
+                        onClick={() => setStep(step - 1)}
+                    >
+                        集金一覧へ戻る
+                    </Button>
                 </Stack>
             </Container>
     );

--- a/front/src/components/manage/list/Process1.tsx
+++ b/front/src/components/manage/list/Process1.tsx
@@ -1,4 +1,4 @@
-import { Button, Container, Stack, TextField, Typography } from "@mui/material";
+import { Button, Container, Paper, Stack, TextField, Typography } from "@mui/material";
 import { BillingData } from "../../types/BillingData";
 
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
@@ -11,6 +11,7 @@ type Props = {
     setStep: React.Dispatch<React.SetStateAction<number>>;
     stepperStep: number;
     setStepperStep: React.Dispatch<React.SetStateAction<number>>;
+    userName: string;
 }
 
 export const Process1 = (props: Props) => {
@@ -20,6 +21,7 @@ export const Process1 = (props: Props) => {
     const setStep = props.setStep;
     const stepperStep = props.stepperStep;
     const setStepperStep = props.setStepperStep;
+    const userName = props.userName;
 
     //一部繰越で、今月支払う金額
     const [paymentPrice, setPaymentPrice] = useState<number>((billingData.price + billingData.beforeCarryOver) - billingData.carryOverPrice);
@@ -38,7 +40,18 @@ export const Process1 = (props: Props) => {
     }
 
     return (
-            <Container sx={{width: "90%", height: "100%", textAlign: "center"}}>
+        <>
+            <Paper elevation={3} sx={{width: "80%", margin: "0 auto"}} children={
+                <Container sx={{width: "80%", height: "150px"}}>
+                    <Stack spacing={0.5} sx={{paddingTop: "20px", textAlign: "center"}}>
+                        <Typography variant='h6'>8月12日 {userName}</Typography>
+                        <Typography variant='h4'>￥{billingData.finalPrice}</Typography>
+                        <hr />
+                        <Typography variant='body1'>支払い予定額  ￥1,500</Typography>
+                    </Stack>
+                </Container>
+            } />
+             <Container sx={{width: "90%", height: "100%", textAlign: "center"}}>
                 <Stack spacing={1} sx={{marginTop: "20px"}}>
                     <Typography variant="h6">集金金額を入力</Typography>
                     <TextField id="user-id" onChange={(event) => setPaymentPrice(Number(event.target.value))} value={paymentPrice} variant="outlined" />
@@ -61,5 +74,7 @@ export const Process1 = (props: Props) => {
                     </Button>
                 </Stack>
             </Container>
+        </>
+           
     );
 }

--- a/front/src/components/manage/list/Process2.tsx
+++ b/front/src/components/manage/list/Process2.tsx
@@ -61,7 +61,7 @@ export const Process2 = (props: Props) => {
                         variant="contained"
                         onClick={() => setStepperStep(stepperStep + 1)}
                     >
-                        次へ
+                        完了
                     </Button>
                     <Button
                         size="small"

--- a/front/src/components/manage/list/Process2.tsx
+++ b/front/src/components/manage/list/Process2.tsx
@@ -1,10 +1,55 @@
+import { useEffect, useState } from "react";
 import { BillingData } from "../../types/BillingData";
+import { Button, Container, Stack, TextField, Typography } from "@mui/material";
+
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 
 type Props = {
     billingData: BillingData;
     setBillingData: React.Dispatch<React.SetStateAction<BillingData>>
+    stepperStep: number;
+    setStepperStep: React.Dispatch<React.SetStateAction<number>>;
 }
 
 export const Process2 = (props: Props) => {
-    return (<h1>ステップ2</h1>);
+    const billingData = props.billingData;
+    const setBillingData = props.setBillingData;
+    const stepperStep = props.stepperStep;
+    const setStepperStep = props.setStepperStep;
+
+    //一部繰越で、今月支払う金額
+    const [keepPrice, setKeepPrice] = useState<number>(0);
+    //今月繰り越す金額
+    const [chargePrice, setChargePrice] = useState<number>(0);
+    
+    //繰越金額の再計算
+    useEffect(() => {
+        setChargePrice(keepPrice - billingData.finalPrice)
+    }, [keepPrice]);
+
+    return (
+            <Container sx={{width: "90%", height: "100%", textAlign: "center"}}>
+                <Stack spacing={1} sx={{marginTop: "20px"}}>
+                    <Typography variant="h6">預かり金額を入力</Typography>
+                    <TextField id="user-id" onChange={(event) => setKeepPrice(Number(event.target.value))} value={keepPrice} variant="outlined" />
+                    <Typography variant="h3"><ArrowDownwardIcon fontSize="large" /></Typography>
+                    <Typography variant="h5">お釣り ￥{chargePrice}</Typography>
+
+                    <Button
+                        size="small"
+                        variant="contained"
+                        onClick={() => setStepperStep(stepperStep + 1)}
+                    >
+                        次へ
+                    </Button>
+                    <Button
+                        size="small"
+                        variant="outlined"
+                        onClick={() => setStepperStep(stepperStep - 1)}
+                    >
+                        戻る
+                    </Button>
+                </Stack>
+            </Container>
+    );
 }

--- a/front/src/components/manage/list/Process2.tsx
+++ b/front/src/components/manage/list/Process2.tsx
@@ -13,7 +13,6 @@ type Props = {
 
 export const Process2 = (props: Props) => {
     const billingData = props.billingData;
-    const setBillingData = props.setBillingData;
     const stepperStep = props.stepperStep;
     const setStepperStep = props.setStepperStep;
 

--- a/front/src/components/manage/list/Process2.tsx
+++ b/front/src/components/manage/list/Process2.tsx
@@ -22,7 +22,7 @@ export const Process2 = (props: Props) => {
     //今月繰り越す金額
     const [chargePrice, setChargePrice] = useState<number>(0);
     
-    //繰越金額の再計算
+    //お釣りの再計算
     useEffect(() => {
         setChargePrice(keepPrice - billingData.finalPrice)
     }, [keepPrice]);
@@ -33,7 +33,18 @@ export const Process2 = (props: Props) => {
                     <Typography variant="h6">預かり金額を入力</Typography>
                     <TextField id="user-id" onChange={(event) => setKeepPrice(Number(event.target.value))} value={keepPrice} variant="outlined" />
                     <Typography variant="h3"><ArrowDownwardIcon fontSize="large" /></Typography>
-                    <Typography variant="h5">お釣り ￥{chargePrice}</Typography>
+                    
+                    {(() => {
+                        if (chargePrice < 0) {
+                            return (
+                                <Typography variant="h5" sx={{color: "error.main"}}>不足 ￥{chargePrice}</Typography>
+                            )
+                        } else {
+                            return (
+                                <Typography variant="h5">お釣り ￥{chargePrice}</Typography>
+                            )
+                        }
+                    })()}
 
                     <Button
                         size="small"

--- a/front/src/components/manage/list/Process2.tsx
+++ b/front/src/components/manage/list/Process2.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { BillingData } from "../../types/BillingData";
-import { Button, Container, Stack, TextField, Typography } from "@mui/material";
+import { Button, Container, Paper, Stack, TextField, Typography } from "@mui/material";
 
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 
@@ -9,12 +9,14 @@ type Props = {
     setBillingData: React.Dispatch<React.SetStateAction<BillingData>>
     stepperStep: number;
     setStepperStep: React.Dispatch<React.SetStateAction<number>>;
+    userName: string;
 }
 
 export const Process2 = (props: Props) => {
     const billingData = props.billingData;
     const stepperStep = props.stepperStep;
     const setStepperStep = props.setStepperStep;
+    const userName = props.userName;
 
     //一部繰越で、今月支払う金額
     const [keepPrice, setKeepPrice] = useState<number>(0);
@@ -27,6 +29,15 @@ export const Process2 = (props: Props) => {
     }, [keepPrice]);
 
     return (
+        <>
+            <Paper elevation={3} sx={{width: "80%", margin: "0 auto"}} children={
+                <Container sx={{width: "80%", height: "120px"}}>
+                    <Stack spacing={0.5} sx={{paddingTop: "20px", textAlign: "center"}}>
+                        <Typography variant='h6'>8月12日 {userName}</Typography>
+                        <Typography variant='h4'>￥{billingData.finalPrice}</Typography>
+                    </Stack>
+                </Container>
+            } />
             <Container sx={{width: "90%", height: "100%", textAlign: "center"}}>
                 <Stack spacing={1} sx={{marginTop: "20px"}}>
                     <Typography variant="h6">預かり金額を入力</Typography>
@@ -61,5 +72,7 @@ export const Process2 = (props: Props) => {
                     </Button>
                 </Stack>
             </Container>
+        </>
+            
     );
 }

--- a/front/src/components/manage/list/Process2.tsx
+++ b/front/src/components/manage/list/Process2.tsx
@@ -1,0 +1,3 @@
+export const Process2 = () => {
+    return (<h1>ステップ2</h1>);
+}

--- a/front/src/components/manage/list/Process2.tsx
+++ b/front/src/components/manage/list/Process2.tsx
@@ -1,3 +1,10 @@
-export const Process2 = () => {
+import { BillingData } from "../../types/BillingData";
+
+type Props = {
+    billingData: BillingData;
+    setBillingData: React.Dispatch<React.SetStateAction<BillingData>>
+}
+
+export const Process2 = (props: Props) => {
     return (<h1>ステップ2</h1>);
 }

--- a/front/src/components/manage/list/Process2.tsx
+++ b/front/src/components/manage/list/Process2.tsx
@@ -6,7 +6,6 @@ import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 
 type Props = {
     billingData: BillingData;
-    setBillingData: React.Dispatch<React.SetStateAction<BillingData>>
     stepperStep: number;
     setStepperStep: React.Dispatch<React.SetStateAction<number>>;
     userName: string;

--- a/front/src/components/manage/list/Process3.tsx
+++ b/front/src/components/manage/list/Process3.tsx
@@ -5,7 +5,6 @@ import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 
 type Props = {
     billingData: BillingData;
-    setBillingData: React.Dispatch<React.SetStateAction<BillingData>>
     step: number;
     setStep: React.Dispatch<React.SetStateAction<number>>;
     userName: string;

--- a/front/src/components/manage/list/Process3.tsx
+++ b/front/src/components/manage/list/Process3.tsx
@@ -1,3 +1,10 @@
-export const Process3 = () => {
+import { BillingData } from "../../types/BillingData";
+
+type Props = {
+    billingData: BillingData;
+    setBillingData: React.Dispatch<React.SetStateAction<BillingData>>
+}
+
+export const Process3 = (props: Props) => {
     return (<h1>ステップ3</h1>);
 }

--- a/front/src/components/manage/list/Process3.tsx
+++ b/front/src/components/manage/list/Process3.tsx
@@ -1,0 +1,3 @@
+export const Process3 = () => {
+    return (<h1>ステップ3</h1>);
+}

--- a/front/src/components/manage/list/Process3.tsx
+++ b/front/src/components/manage/list/Process3.tsx
@@ -1,10 +1,43 @@
+import { Button, Container, Stack, Typography } from "@mui/material";
 import { BillingData } from "../../types/BillingData";
+
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 
 type Props = {
     billingData: BillingData;
     setBillingData: React.Dispatch<React.SetStateAction<BillingData>>
+    step: number;
+    setStep: React.Dispatch<React.SetStateAction<number>>;
+    userName: string;
 }
 
 export const Process3 = (props: Props) => {
-    return (<h1>ステップ3</h1>);
+    const billingData = props.billingData;
+    const step = props.step;
+    const setStep = props.setStep;
+    const userName = props.userName;
+
+    return (
+        <Container sx={{width: "90%", height: "100%", textAlign: "center"}}>
+            <CheckCircleOutlineIcon sx={{width: "150px", height: "auto", color: "success.main"}} />
+            <Typography variant="h3">集金完了</Typography>
+
+            <Stack spacing={1} sx={{marginTop: "20px"}}>
+                <Typography variant="h5">＜対象者＞</Typography>
+                <Typography variant="h6">氏名：{userName}</Typography>
+                <Typography variant="h6">集金額：￥{billingData.finalPrice}</Typography>
+                <Typography variant="h6">繰越額：￥{billingData.carryOverPrice}</Typography>
+            </Stack>
+
+            <Stack spacing={1} sx={{marginTop: "20px"}}>
+                <Button
+                        size="small"
+                        variant="contained"
+                        onClick={() => setStep(step - 1)}
+                    >
+                        完了
+                </Button>
+            </Stack>
+        </Container>
+    );
 }

--- a/front/src/components/manage/list/Select.tsx
+++ b/front/src/components/manage/list/Select.tsx
@@ -8,6 +8,7 @@ type Props = {
     setStep: React.Dispatch<React.SetStateAction<number>>;
     userId: string;
     setUserId: React.Dispatch<React.SetStateAction<string>>;
+    setUserName: React.Dispatch<React.SetStateAction<string>>;
 }
 
 interface BillListData {
@@ -21,6 +22,7 @@ interface BillListData {
 export const Select = (props: Props) => {
     const setStep = props.setStep;
     const setUserId = props.setUserId;
+    const setUserName = props.setUserName;
 
     const listData: BillListData[] = [
         {no: 1, userId: "test1", name: "山田 太郎", finalPrice: 3500, paid: 0},
@@ -43,7 +45,7 @@ export const Select = (props: Props) => {
           <TableBody>
             {listData.map((data) => (
               <TableRow
-                onClick={() => {setUserId(data.userId); setStep(1);}}
+                onClick={() => {setUserId(data.userId); setUserName(data.name); setStep(1);}}
                 key={data.no}
                 sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
                 style={{cursor: "pointer"}}

--- a/front/src/components/manage/list/Select.tsx
+++ b/front/src/components/manage/list/Select.tsx
@@ -38,9 +38,9 @@ export const Select = (props: Props) => {
           <TableHead>
             <TableRow>
               <TableCell align="center">部屋No.</TableCell>
-              <TableCell sx={{ minWidth: 150 }} align="center">氏名</TableCell>
+              <TableCell sx={{ minWidth: 70 }} align="center">氏名</TableCell>
               <TableCell align="right">請求予定額</TableCell>
-              <TableCell align="right">チェック</TableCell>
+              <TableCell align="center">チェック</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -54,24 +54,24 @@ export const Select = (props: Props) => {
                 <TableCell component="th" scope="row" align="center">
                   {data.no}
                 </TableCell>
-                <TableCell sx={{ minWidth: 150 }} align="center">{data.name}</TableCell>
+                <TableCell sx={{ minWidth: 70 }} align="center">{data.name}</TableCell>
                 <TableCell align="right">￥{data.finalPrice}</TableCell>
                 {(() => {
                 if (data.paid === 0) {
                     return (
-                        <TableCell align="right"><HorizontalRuleIcon /></TableCell>
+                        <TableCell align="center"><HorizontalRuleIcon /></TableCell>
                     )
                 } else if (data.paid === 1) {
                     return (
-                        <TableCell align="right"><CheckIcon /></TableCell>
+                        <TableCell align="center"><CheckIcon /></TableCell>
                     )
                 } else if (data.paid === 2) {
                     return (
-                        <TableCell align="right"><ChangeCircleIcon /></TableCell>
+                        <TableCell align="center"><ChangeCircleIcon /></TableCell>
                     )
                 } else {
                     return (
-                        <TableCell align="right"></TableCell>
+                        <TableCell align="center"></TableCell>
                     )
                 }
             })()}

--- a/front/src/components/manage/list/Select.tsx
+++ b/front/src/components/manage/list/Select.tsx
@@ -29,7 +29,7 @@ export const Select = (props: Props) => {
     ];
 
     return (
-        <Container sx={{width: "90%", marginTop: "30px"}}>
+        <Container sx={{width: "90%", height: "100%", marginTop: "30px"}}>
             <TableContainer component={Paper}>
         <Table sx={{ minWidth: 500}} aria-label="simple table">
           <TableHead>

--- a/front/src/components/manage/list/Select.tsx
+++ b/front/src/components/manage/list/Select.tsx
@@ -1,4 +1,4 @@
-import { Container, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from "@mui/material"
+import { Container, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography } from "@mui/material"
 import CheckIcon from '@mui/icons-material/Check';
 import ChangeCircleIcon from '@mui/icons-material/ChangeCircle';
 import HorizontalRuleIcon from '@mui/icons-material/HorizontalRule';
@@ -32,6 +32,7 @@ export const Select = (props: Props) => {
 
     return (
         <Container sx={{width: "90%", height: "100%", marginTop: "30px"}}>
+          <Typography variant="h4">請求一覧</Typography>
             <TableContainer component={Paper}>
         <Table sx={{ minWidth: 500}} aria-label="simple table">
           <TableHead>

--- a/front/src/components/types/BillingData.ts
+++ b/front/src/components/types/BillingData.ts
@@ -1,0 +1,12 @@
+export type BillingData = {
+    billingId: string;
+    userId: string;
+    useAmount: number;
+    price: number;
+    beforeCarryOver: number;
+    carryOverType: string;
+    carryOverPrice: number;
+    finalPrice: number;
+    dateId: number;
+    paid: number;
+};

--- a/front/src/components/user/billing/Billing.tsx
+++ b/front/src/components/user/billing/Billing.tsx
@@ -10,7 +10,7 @@ import FormControl from '@mui/material/FormControl';
 import "./Billing.scss";
 
 import { PaymentOption } from './PaymentOption';
-import { Box, Container, Grid, Stack, Tab, Tabs, Typography } from '@mui/material';
+import { Container, Grid, Stack, Tab, Tabs, Typography } from '@mui/material';
 
 import { BillingData } from '../../types/BillingData';
 

--- a/front/src/components/user/billing/Billing.tsx
+++ b/front/src/components/user/billing/Billing.tsx
@@ -12,18 +12,7 @@ import "./Billing.scss";
 import { PaymentOption } from './PaymentOption';
 import { Box, Container, Grid, Stack, Tab, Tabs, Typography } from '@mui/material';
 
-interface BillingData {
-    billingId: string;
-    userId: string;
-    useAmount: number;
-    price: number;
-    beforeCarryOver: number;
-    carryOverType: string;
-    carryOverPrice: number;
-    finalPrice: number;
-    dateId: number;
-    paid: number;
-};
+import { BillingData } from '../../types/BillingData';
 
 export const NextBilling = () => {
     const [billingData, setBillingData] = useState<BillingData>({billingId: "test01", userId: "kait", useAmount: 350, price: 3000, beforeCarryOver: 0, carryOverType: "no", carryOverPrice: 0, finalPrice: 3000, dateId: 0, paid: 0});

--- a/front/src/components/user/billing/PaymentOption.tsx
+++ b/front/src/components/user/billing/PaymentOption.tsx
@@ -3,18 +3,7 @@ import { useEffect, useState } from "react";
 
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 
-interface BillingData {
-    billingId: string;
-    userId: string;
-    useAmount: number;
-    price: number;
-    beforeCarryOver: number;
-    carryOverType: string;
-    carryOverPrice: number;
-    finalPrice: number;
-    dateId: number;
-    paid: number;
-};
+import { BillingData } from "../../types/BillingData";
 
 type Props = {
     billingData: BillingData,


### PR DESCRIPTION
# 変更
以下の処理画面を作成した。
* step1：集金金額を入力して「次へ」を押すと、週金額と繰越額のデータが更新される（アプリ内で）
* step2：集金金額に対する預かり金額を入力すると、自動でお釣りを計算する。足りない場合は不足額が表示される
* step3：集金完了と表示され、週金額と繰越額が表示される

請求一覧の表のレイアウトを調整した。

# issue
closed #20 
closed #22