### PR TITLE
billingDataの扱いを変更し、請求額を自動で計算できるようにした。

### DIFF
--- a/front/src/components/manage/list/Process.tsx
+++ b/front/src/components/manage/list/Process.tsx
@@ -22,7 +22,7 @@ export const Process = (props: Props) => {
     const [stepperStep, setStepperStep] = useState<number>(0);
 
     //請求データを格納する
-    const [billingData, setBillingData] = useState<BillingData>({billingId: "test01", userId: "kait", useAmount: 350, price: 3000, beforeCarryOver: 0, carryOverType: "no", carryOverPrice: 0, finalPrice: 3000, dateId: 0, paid: 0});
+    const [billingData, setBillingData] = useState<BillingData>({billingId: "test01", userId: "kait", useAmount: 350, price: 3000, beforeCarryOver: 0, carryOverType: "no", carryOverPrice: 0, dateId: 0, paidPrice: 0, paid: 0});
 
     const [tabValue, setTabValue] = useState<string>("1");
 

--- a/front/src/components/manage/list/Process1.tsx
+++ b/front/src/components/manage/list/Process1.tsx
@@ -35,7 +35,7 @@ export const Process1 = (props: Props) => {
 
     //請求情報更新
     const upDateBillData = () => {
-        const newBillingData: BillingData = {billingId: "test01", userId: "kait", useAmount: 350, price: 3000, beforeCarryOver: 0, carryOverType: "no", carryOverPrice: carryOverPrice, finalPrice: paymentPrice, dateId: 0, paid: 0};
+        const newBillingData: BillingData = {billingId: "test01", userId: "kait", useAmount: 350, price: 3000, beforeCarryOver: 0, carryOverType: "no", carryOverPrice: carryOverPrice, dateId: 0, paidPrice: paymentPrice, paid: 0};
         setBillingData(newBillingData);
     }
 
@@ -45,9 +45,9 @@ export const Process1 = (props: Props) => {
                 <Container sx={{width: "80%", height: "150px"}}>
                     <Stack spacing={0.5} sx={{paddingTop: "20px", textAlign: "center"}}>
                         <Typography variant='h6'>8月12日 {userName}</Typography>
-                        <Typography variant='h4'>￥{billingData.finalPrice}</Typography>
+                        <Typography variant='h4'>￥{billingData.beforeCarryOver + billingData.price}</Typography>
                         <hr />
-                        <Typography variant='body1'>支払い予定額  ￥1,500</Typography>
+                        <Typography variant='body1'>支払い予定額  ￥{(billingData.beforeCarryOver + billingData.price) - billingData.carryOverPrice}</Typography>
                     </Stack>
                 </Container>
             } />

--- a/front/src/components/manage/list/Process2.tsx
+++ b/front/src/components/manage/list/Process2.tsx
@@ -24,7 +24,7 @@ export const Process2 = (props: Props) => {
     
     //お釣りの再計算
     useEffect(() => {
-        setChargePrice(keepPrice - billingData.finalPrice)
+        setChargePrice(keepPrice - billingData.paidPrice);
     }, [keepPrice]);
 
     return (
@@ -33,7 +33,7 @@ export const Process2 = (props: Props) => {
                 <Container sx={{width: "80%", height: "120px"}}>
                     <Stack spacing={0.5} sx={{paddingTop: "20px", textAlign: "center"}}>
                         <Typography variant='h6'>8月12日 {userName}</Typography>
-                        <Typography variant='h4'>￥{billingData.finalPrice}</Typography>
+                        <Typography variant='h4'>￥{billingData.paidPrice}</Typography>
                     </Stack>
                 </Container>
             } />

--- a/front/src/components/manage/list/Process3.tsx
+++ b/front/src/components/manage/list/Process3.tsx
@@ -24,7 +24,7 @@ export const Process3 = (props: Props) => {
             <Stack spacing={1} sx={{marginTop: "20px"}}>
                 <Typography variant="h5">＜対象者＞</Typography>
                 <Typography variant="h6">氏名：{userName}</Typography>
-                <Typography variant="h6">集金額：￥{billingData.finalPrice}</Typography>
+                <Typography variant="h6">集金額：￥{billingData.paidPrice}</Typography>
                 <Typography variant="h6">繰越額：￥{billingData.carryOverPrice}</Typography>
             </Stack>
 

--- a/front/src/components/types/BillingData.ts
+++ b/front/src/components/types/BillingData.ts
@@ -6,7 +6,7 @@ export type BillingData = {
     beforeCarryOver: number;
     carryOverType: string;
     carryOverPrice: number;
-    finalPrice: number;
     dateId: number;
+    paidPrice: number;
     paid: number;
 };

--- a/front/src/components/user/billing/Billing.tsx
+++ b/front/src/components/user/billing/Billing.tsx
@@ -15,7 +15,7 @@ import { Container, Grid, Stack, Tab, Tabs, Typography } from '@mui/material';
 import { BillingData } from '../../types/BillingData';
 
 export const NextBilling = () => {
-    const [billingData, setBillingData] = useState<BillingData>({billingId: "test01", userId: "kait", useAmount: 350, price: 3000, beforeCarryOver: 0, carryOverType: "no", carryOverPrice: 0, finalPrice: 3000, dateId: 0, paid: 0});
+    const [billingData, setBillingData] = useState<BillingData>({billingId: "test01", userId: "kait", useAmount: 350, price: 3000, beforeCarryOver: 0, carryOverType: "no", carryOverPrice: 0, dateId: 0, paidPrice: 0, paid: 0});
     const [value, setValue] = useState<string>('no');
 
     const [tabValue, setTabValue] = useState<string>("0");
@@ -23,7 +23,7 @@ export const NextBilling = () => {
 
     //請求額を設定する
     useEffect(() => {
-        const billingDataSrc: BillingData = {billingId: "test01", userId: "kait", useAmount: 350, price: 3000, beforeCarryOver: 0, carryOverType: "no", carryOverPrice: 0, finalPrice: 3000, dateId: 0, paid: 0};
+        const billingDataSrc: BillingData = {billingId: "test01", userId: "kait", useAmount: 350, price: 3000, beforeCarryOver: 0, carryOverType: "no", carryOverPrice: 0, dateId: 0, paidPrice: 0, paid: 0};
         setBillingData(billingDataSrc);
     }, []);
 
@@ -46,9 +46,9 @@ export const NextBilling = () => {
                 <Container sx={{width: "80%", height: "150px"}}>
                     <Stack spacing={0.5} sx={{paddingTop: "20px", textAlign: "center"}}>
                         <Typography variant='h6'>8月12日 請求金額</Typography>
-                        <Typography variant='h4'>￥{billingData.finalPrice}</Typography>
+                        <Typography variant='h4'>￥{billingData.beforeCarryOver + billingData.price}</Typography>
                         <hr />
-                        <Typography variant='body1'>支払い予定額  ￥1,500</Typography>
+                        <Typography variant='body1'>支払い予定額  ￥{(billingData.beforeCarryOver + billingData.price) - billingData.carryOverPrice}</Typography>
                     </Stack>
                 </Container>
             } />


### PR DESCRIPTION
# 変更
* billingDataの型から、finalPriceを削除して、paidPriceを追加した。
* finalPriceを利用していた部分は、billingData.beforeCarryOver + billingData.price　を計算して求めるようにした。

# issue
closed #31 