### PR TITLE
額入力時のエラー処理を書いた

### DIFF
--- a/front/src/components/manage/list/Process2.tsx
+++ b/front/src/components/manage/list/Process2.tsx
@@ -21,10 +21,17 @@ export const Process2 = (props: Props) => {
     const [keepPrice, setKeepPrice] = useState<number>(0);
     //今月繰り越す金額
     const [chargePrice, setChargePrice] = useState<number>(0);
+
+    const [finishDisabled, setFinishDisabled] = useState<boolean>(false);
     
     //お釣りの再計算
     useEffect(() => {
         setChargePrice(keepPrice - billingData.paidPrice);
+        if ((keepPrice - billingData.paidPrice) < 0 ) {
+            setFinishDisabled(true);
+        } else {
+            setFinishDisabled(false);
+        }
     }, [keepPrice]);
 
     return (
@@ -65,6 +72,7 @@ export const Process2 = (props: Props) => {
                         size="small"
                         variant="contained"
                         onClick={() => setStepperStep(stepperStep + 1)}
+                        disabled={finishDisabled}
                     >
                         完了
                     </Button>

--- a/front/src/components/user/billing/PaymentOption.tsx
+++ b/front/src/components/user/billing/PaymentOption.tsx
@@ -23,6 +23,11 @@ export const PaymentOption = (props: Props) => {
 
     useEffect(() => {
         setCarryOverPrice((billingData.price + billingData.beforeCarryOver) - paymentPrice)
+        if (paymentPrice === 0) {
+            setSaveDisabled(true);
+        } else {
+            setSaveDisabled(false);
+        }
     }, [paymentPrice]);
 
     //既に設定されているオプションの場合、「変更を保存」ボタンは無効にする

--- a/front/src/components/user/billing/PaymentOption.tsx
+++ b/front/src/components/user/billing/PaymentOption.tsx
@@ -85,8 +85,23 @@ export const PaymentOption = (props: Props) => {
                     <Typography variant="h6">今月支払う金額を入力</Typography>
                     <TextField id="user-id" onChange={(event) => setPaymentPrice(Number(event.target.value))} value={paymentPrice} variant="outlined" />
                     <Typography variant="h3"><ArrowDownwardIcon fontSize="large" /></Typography>
-                    <Typography variant="h6">繰越金額</Typography>
-                    <Typography variant="h3">￥{carryOverPrice}</Typography>
+                    {(() => {
+                        if (carryOverPrice < 0) {
+                            return (
+                                <>
+                                    <Typography variant="h6" sx={{color: "error.main"}}>繰越金額（不正です）</Typography>
+                                    <Typography variant="h3" sx={{color: "error.main"}}>￥{carryOverPrice}</Typography>
+                                </>
+                            )
+                        } else {
+                            return (
+                                <>
+                                    <Typography variant="h6">繰越金額</Typography>
+                                    <Typography variant="h3">￥{carryOverPrice}</Typography>
+                                </>
+                            )
+                        }
+                    })()}
                     <Button
                         size="small"
                         variant="contained"

--- a/front/src/components/user/billing/PaymentOption.tsx
+++ b/front/src/components/user/billing/PaymentOption.tsx
@@ -39,9 +39,9 @@ export const PaymentOption = (props: Props) => {
         }
     }, [carryOverType]);
 
-    //既に設定されている繰越額と同じ金額の場合、「変更を保存」ボタンは無効にする
+    //既に設定されている繰越額と同じ金額 または繰越額が0の場合、「変更を保存」ボタンは無効にする
     useEffect(() => {
-        if (billingData.carryOverPrice === carryOverPrice) {
+        if ((billingData.carryOverPrice === carryOverPrice) || (carryOverPrice <= 0)) {
             setSaveDisabled(true);
         } else {
             setSaveDisabled(false);


### PR DESCRIPTION
# 変更
* 一部繰越のところで支払額0の時に、「保存」を押せないようにした。
* 預かり額の入力のところで、不足があるときは「完了」を押せないようにした。