### PR TITLE
ユーザー側の画面にjoy uiを導入した

### DIFF
--- a/react-front/package-lock.json
+++ b/react-front/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
+        "@fontsource/inter": "^5.0.8",
         "@mui/icons-material": "^5.14.3",
+        "@mui/joy": "^5.0.0-beta.2",
         "@mui/material": "^5.14.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -969,6 +971,11 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@fontsource/inter": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.0.8.tgz",
+      "integrity": "sha512-28knWH1BfOiRalfLs90U4sge5mpQ8ZH6FS0PTT+IZMKrZ7wNHDHRuKa1kQJg+uHcc6axBppnxll+HXM4c7zo/Q=="
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
@@ -1111,6 +1118,48 @@
         "react": "^17.0.0 || ^18.0.0"
       },
       "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/joy": {
+      "version": "5.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@mui/joy/-/joy-5.0.0-beta.2.tgz",
+      "integrity": "sha512-5NfZcOYufTOSXh0b34YZzF1CHwuHf07cgSNdyn3WUUwg67oyNOPKhaskttX6aSp0j8Rf8OpKzd+7Ni6Em0jPgQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.6",
+        "@mui/base": "5.0.0-beta.11",
+        "@mui/core-downloads-tracker": "^5.14.5",
+        "@mui/system": "^5.14.5",
+        "@mui/types": "^7.2.4",
+        "@mui/utils": "^5.14.5",
+        "clsx": "^2.0.0",
+        "csstype": "^3.1.2",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
         "@types/react": {
           "optional": true
         }

--- a/react-front/package.json
+++ b/react-front/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
+    "@fontsource/inter": "^5.0.8",
     "@mui/icons-material": "^5.14.3",
+    "@mui/joy": "^5.0.0-beta.2",
     "@mui/material": "^5.14.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/react-front/src/components/manage/LoginFormM.tsx
+++ b/react-front/src/components/manage/LoginFormM.tsx
@@ -1,66 +1,54 @@
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 import { LoginFlagContext } from '../providers/LoginFlagProvider';
 
 import Container from '@mui/material/Container';
 import Stack from '@mui/material/Stack';
 
-import TextField from '@mui/material/TextField';
-import Button from '@mui/material/Button';
-
-//フォームの処理
-import { useForm } from 'react-hook-form';
-import { ThemeProvider, createTheme } from '@mui/material';
-
-type FormValues = {
-  userId: string;
-  password: string;
-};
+//import TextField from '@mui/material/TextField';
+//import Button from '@mui/material/Button';
+import { Input, Button } from '@mui/joy';
 
 export const LoginFormM = () => {
   const { setLoginFlag } = useContext(LoginFlagContext);
 
-  const { register, handleSubmit } = useForm<FormValues>();
-  const onSubmit = handleSubmit((data) => {
-    if (data.userId === 'test' && data.password === '1234') {
+  const [userId, setUserId] = useState<string>('');
+  const [password, setPassword] = useState<string>('');
+
+  const onSubmit = () => {
+    if (userId === 'test' && password === '1234') {
       setLoginFlag(true);
     }
-  });
+  };
 
-  const loginTheme = createTheme({
+  /*const loginTheme = createTheme({
     palette: {
       mode: 'light',
       primary: {
         main: '#000',
       },
     },
-  });
+  });*/
 
   return (
     <Container maxWidth="sm">
-      <form onSubmit={onSubmit}>
-        <ThemeProvider theme={loginTheme}>
-          <Stack spacing={2}>
-            <br></br>
-            <h1>ログイン</h1>
-            <TextField
-              {...register('userId')}
-              id="standard-basic"
-              label="ユーザ名"
-              variant="standard"
-            />
-            <br />
-            <TextField
-              {...register('password')}
-              id="standard-password-input"
-              label="パスワード"
-              type="password"
-              autoComplete="current-password"
-              variant="standard"
-            />
-            <br />
-            <Button type="submit">ログイン</Button>
-          </Stack>
-        </ThemeProvider>
+      <form>
+        <Stack spacing={1}>
+          <br></br>
+          <h1>ログイン</h1>
+          <Input
+            placeholder="ユーザID"
+            onChange={(event) => setUserId(event.target.value)}
+          />
+          <br />
+          <Input
+            placeholder="パスワード"
+            onChange={(event) => setPassword(event.target.value)}
+          />
+          <br />
+          <Button color="neutral" onClick={onSubmit} variant="solid">
+            ログイン
+          </Button>
+        </Stack>
       </form>
     </Container>
   );

--- a/react-front/src/components/manage/input/Input.tsx
+++ b/react-front/src/components/manage/input/Input.tsx
@@ -28,6 +28,9 @@ export const Input = () => {
   const [yearValue, setYearValue] = useState<number | string>('');
   const [manthValue, setManthValue] = useState<number | string>('');
 
+  const yearList: number[] = [2022, 2023];
+  const manthList: number[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+
   const [listData, setListData] = useState<BillInputList[]>([
     { no: 1, name: '井上 太郎', useAmount: 0, price: 0, beforeCarryOver: 2000 },
     { no: 2, name: '鈴木 太郎', useAmount: 0, price: 0, beforeCarryOver: 0 },
@@ -73,8 +76,9 @@ export const Input = () => {
             <MenuItem value="">
               <em>年を選択</em>
             </MenuItem>
-            <MenuItem value={2022}>2022年</MenuItem>
-            <MenuItem value={2023}>2023年</MenuItem>
+            {yearList.map((year) => (
+              <MenuItem value={year}>{year}年</MenuItem>
+            ))}
           </Select>
         </Grid>
         <Grid item xs={3}>
@@ -88,18 +92,9 @@ export const Input = () => {
             <MenuItem value="">
               <em>月を選択</em>
             </MenuItem>
-            <MenuItem value={1}>1月</MenuItem>
-            <MenuItem value={2}>2月</MenuItem>
-            <MenuItem value={3}>3月</MenuItem>
-            <MenuItem value={4}>4月</MenuItem>
-            <MenuItem value={5}>5月</MenuItem>
-            <MenuItem value={6}>6月</MenuItem>
-            <MenuItem value={7}>7月</MenuItem>
-            <MenuItem value={8}>8月</MenuItem>
-            <MenuItem value={9}>9月</MenuItem>
-            <MenuItem value={10}>10月</MenuItem>
-            <MenuItem value={11}>11月</MenuItem>
-            <MenuItem value={12}>12月</MenuItem>
+            {manthList.map((manth) => (
+              <MenuItem value={manth}>{manth}月</MenuItem>
+            ))}
           </Select>
         </Grid>
         <Grid item xs={1.2}>

--- a/react-front/src/components/providers/billingDataProvider.tsx
+++ b/react-front/src/components/providers/billingDataProvider.tsx
@@ -1,0 +1,33 @@
+import { Dispatch, SetStateAction, createContext, useState } from 'react';
+import { BillingData } from '../types/BillingData';
+
+export const BillingContext = createContext(
+  {} as {
+    billingData: BillingData;
+    setBillingData: Dispatch<SetStateAction<BillingData>>;
+  },
+);
+
+export const BillingDataProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  //請求データを保存するステート
+  const [billingData, setBillingData] = useState<BillingData>({
+    billingId: 'test01',
+    userId: 'kait',
+    useAmount: 350,
+    price: 3000,
+    beforeCarryOver: 0,
+    carryOverType: 'no',
+    carryOverPrice: 0,
+    dateId: 0,
+    paidPrice: 0,
+    paid: 0,
+  });
+
+  return (
+    <BillingContext.Provider value={{ billingData, setBillingData }}>
+      {children}
+    </BillingContext.Provider>
+  );
+};

--- a/react-front/src/components/user/LoginForm.tsx
+++ b/react-front/src/components/user/LoginForm.tsx
@@ -1,67 +1,54 @@
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 import { LoginFlagContext } from '../providers/LoginFlagProvider';
 
 import Container from '@mui/material/Container';
 import Stack from '@mui/material/Stack';
 
-import TextField from '@mui/material/TextField';
-import Button from '@mui/material/Button';
-
-//フォームの処理
-import { useForm } from 'react-hook-form';
-import { createTheme } from '@mui/material';
-import { ThemeProvider } from '@emotion/react';
-
-type FormValues = {
-  userId: string;
-  password: string;
-};
+//import TextField from '@mui/material/TextField';
+//import Button from '@mui/material/Button';
+import { Input, Button } from '@mui/joy';
 
 export const LoginForm = () => {
   const { setLoginFlag } = useContext(LoginFlagContext);
 
-  const { register, handleSubmit } = useForm<FormValues>();
-  const onSubmit = handleSubmit((data) => {
-    if (data.userId === 'test' && data.password === '1234') {
+  const [userId, setUserId] = useState<string>('');
+  const [password, setPassword] = useState<string>('');
+
+  const onSubmit = () => {
+    if (userId === 'test' && password === '1234') {
       setLoginFlag(true);
     }
-  });
+  };
 
-  const loginTheme = createTheme({
+  /*const loginTheme = createTheme({
     palette: {
       mode: 'light',
       primary: {
         main: '#000',
       },
     },
-  });
+  });*/
 
   return (
     <Container maxWidth="sm">
-      <form onSubmit={onSubmit}>
-        <ThemeProvider theme={loginTheme}>
-          <Stack spacing={2}>
-            <br></br>
-            <h1>ログイン</h1>
-            <TextField
-              {...register('userId')}
-              id="standard-basic"
-              label="ユーザ名"
-              variant="standard"
-            />
-            <br />
-            <TextField
-              {...register('password')}
-              id="standard-password-input"
-              label="パスワード"
-              type="password"
-              autoComplete="current-password"
-              variant="standard"
-            />
-            <br />
-            <Button type="submit">ログイン</Button>
-          </Stack>
-        </ThemeProvider>
+      <form>
+        <Stack spacing={1}>
+          <br></br>
+          <h1>ログイン</h1>
+          <Input
+            placeholder="ユーザID"
+            onChange={(event) => setUserId(event.target.value)}
+          />
+          <br />
+          <Input
+            placeholder="パスワード"
+            onChange={(event) => setPassword(event.target.value)}
+          />
+          <br />
+          <Button color="neutral" onClick={onSubmit} variant="solid">
+            ログイン
+          </Button>
+        </Stack>
       </form>
     </Container>
   );

--- a/react-front/src/components/user/UserViewController.tsx
+++ b/react-front/src/components/user/UserViewController.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
 
-import Container from '@mui/material/Container';
-
-import BottomNavigation from '@mui/material/BottomNavigation';
-import BottomNavigationAction from '@mui/material/BottomNavigationAction';
+import {
+  Container,
+  BottomNavigation,
+  BottomNavigationAction,
+} from '@mui/material';
 
 import HomeIcon from '@mui/icons-material/Home';
 import CurrencyYenIcon from '@mui/icons-material/CurrencyYen';

--- a/react-front/src/components/user/UserViewController.tsx
+++ b/react-front/src/components/user/UserViewController.tsx
@@ -10,52 +10,28 @@ import CurrencyYenIcon from '@mui/icons-material/CurrencyYen';
 import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
 
 import { UserViewContents } from './UserViewContents';
-import { ThemeProvider, createTheme } from '@mui/material';
 
 export const UserViewController = () => {
   const [navigationValue, setNavigationValue] = useState<number>(0);
 
-  const userNavTheme = createTheme({
-    palette: {
-      mode: 'light',
-      primary: {
-        main: '#26c988',
-      },
-    },
-    components: {
-      MuiButton: {
-        styleOverrides: {
-          root: {
-            borderRadius: '10px',
-          },
-        },
-      },
-    },
-  });
-
   return (
     <div>
       <Container maxWidth="md" style={{ height: '70vh' }}>
-        <ThemeProvider theme={userNavTheme}>
-          <UserViewContents contentsNo={navigationValue} />
-          <BottomNavigation
-            showLabels
-            value={navigationValue}
-            onChange={(event, newValue) => {
-              setNavigationValue(newValue);
-            }}
-          >
-            <BottomNavigationAction label="請求入力" icon={<HomeIcon />} />
-            <BottomNavigationAction
-              label="請求一覧"
-              icon={<CurrencyYenIcon />}
-            />
-            <BottomNavigationAction
-              label="請求日設定"
-              icon={<FormatListBulletedIcon />}
-            />
-          </BottomNavigation>
-        </ThemeProvider>
+        <UserViewContents contentsNo={navigationValue} />
+        <BottomNavigation
+          showLabels
+          value={navigationValue}
+          onChange={(event, newValue) => {
+            setNavigationValue(newValue);
+          }}
+        >
+          <BottomNavigationAction label="請求入力" icon={<HomeIcon />} />
+          <BottomNavigationAction label="請求一覧" icon={<CurrencyYenIcon />} />
+          <BottomNavigationAction
+            label="請求日設定"
+            icon={<FormatListBulletedIcon />}
+          />
+        </BottomNavigation>
       </Container>
     </div>
   );

--- a/react-front/src/components/user/billing/Billing.tsx
+++ b/react-front/src/components/user/billing/Billing.tsx
@@ -8,21 +8,10 @@ import FormControlLabel from '@mui/material/FormControlLabel';
 import FormControl from '@mui/material/FormControl';
 
 import { PaymentOption } from './PaymentOption';
-import {
-  Button,
-  Container,
-  Grid,
-  MenuItem,
-  Select,
-  Stack,
-  Tab,
-  Tabs,
-  Typography,
-} from '@mui/material';
+import { Container, Stack, Tab, Tabs, Typography } from '@mui/material';
 
 import { BillingData } from '../../types/BillingData';
-
-import PublicIcon from '@mui/icons-material/Public';
+import { OverView } from './tab-contents/OverView';
 
 export const NextBilling = () => {
   const [billingData, setBillingData] = useState<BillingData>({
@@ -40,12 +29,6 @@ export const NextBilling = () => {
   const [value, setValue] = useState<string>('no');
 
   const [tabValue, setTabValue] = useState<string>('0');
-
-  const comparePrice = -1000;
-  const compareCo2 = -30;
-
-  const [yearValue, setYearValue] = useState<number | string>('');
-  const [manthValue, setManthValue] = useState<number | string>('');
 
   const setFailedData = () => {
     const data: BillingData = {
@@ -150,147 +133,7 @@ export const NextBilling = () => {
       />
       {(() => {
         if (tabValue === '0') {
-          return (
-            <Container sx={{ width: '80%', marginBottom: '50px' }}>
-              <Grid container spacing={1}>
-                <Grid item xs={6} sx={{ textAlign: 'center' }}>
-                  <Stack
-                    spacing={0.5}
-                    sx={{ paddingTop: '20px', textAlign: 'center' }}
-                  >
-                    <Typography variant="body1">使用量</Typography>
-                    <Typography variant="h4">
-                      {billingData.useAmount} kWh
-                    </Typography>
-                  </Stack>
-                </Grid>
-                <Grid item xs={6} sx={{ textAlign: 'center' }}>
-                  <Stack
-                    spacing={0.5}
-                    sx={{ paddingTop: '20px', textAlign: 'center' }}
-                  >
-                    <Typography variant="body1">〜先月 繰越額</Typography>
-                    <Typography variant="h4">
-                      ￥{billingData.beforeCarryOver}
-                    </Typography>
-                  </Stack>
-                </Grid>
-                <Grid item xs={6} sx={{ textAlign: 'center' }}>
-                  <Stack
-                    spacing={0.5}
-                    sx={{ paddingTop: '20px', textAlign: 'center' }}
-                  >
-                    <Typography variant="body1">請求額</Typography>
-                    <Typography variant="h4">￥{billingData.price}</Typography>
-                  </Stack>
-                </Grid>
-                <Grid item xs={6} sx={{ textAlign: 'center' }}>
-                  <Stack
-                    spacing={0.5}
-                    sx={{ paddingTop: '20px', textAlign: 'center' }}
-                  >
-                    <Typography variant="body1">今月 繰越額(予定)</Typography>
-                    <Typography variant="h4">
-                      ￥{billingData.carryOverPrice}
-                    </Typography>
-                  </Stack>
-                </Grid>
-                <Grid item xs={6} sx={{ textAlign: 'center' }}>
-                  <Stack
-                    spacing={0.5}
-                    sx={{ paddingTop: '20px', textAlign: 'center' }}
-                  >
-                    <Typography variant="body1" sx={{ fontWeight: 'bold' }}>
-                      先月 請求額比較
-                    </Typography>
-                    {comparePrice <= 0 ? (
-                      <Typography variant="h4" sx={{ color: 'success.main' }}>
-                        ￥{comparePrice}
-                      </Typography>
-                    ) : (
-                      <Typography variant="h4" sx={{ color: 'error.main' }}>
-                        ￥{comparePrice}
-                      </Typography>
-                    )}
-                  </Stack>
-                </Grid>
-                <Grid item xs={6} sx={{ textAlign: 'center' }}>
-                  <Stack
-                    spacing={0.5}
-                    sx={{ paddingTop: '20px', textAlign: 'center' }}
-                  >
-                    <Typography variant="body1" sx={{ fontWeight: 'bold' }}>
-                      先月 CO2削減量
-                    </Typography>
-                    {compareCo2 <= 0 ? (
-                      <Typography variant="h4" sx={{ color: 'success.main' }}>
-                        <PublicIcon fontSize="large" />
-                        {compareCo2}kg
-                      </Typography>
-                    ) : (
-                      <Typography variant="h4" sx={{ color: 'error.main' }}>
-                        {compareCo2}kg
-                      </Typography>
-                    )}
-                  </Stack>
-                </Grid>
-              </Grid>
-              <Stack spacing={0.5} sx={{ marginTop: '30px' }}>
-                <Typography variant="h5">表示する年・月を選択</Typography>
-                <Grid container spacing={2}>
-                  <Grid item xs={4} sx={{ textAlign: 'center' }}>
-                    <Select
-                      value={yearValue}
-                      onChange={(event) =>
-                        setYearValue(Number(event.target.value))
-                      }
-                      displayEmpty
-                      inputProps={{ 'aria-label': 'Without label' }}
-                      size="small"
-                    >
-                      <MenuItem value="">
-                        <em>年を選択</em>
-                      </MenuItem>
-                      <MenuItem value={2022}>2022年</MenuItem>
-                      <MenuItem value={2023}>2023年</MenuItem>
-                    </Select>
-                  </Grid>
-                  <Grid item xs={3} sx={{ textAlign: 'center' }}>
-                    <Select
-                      value={manthValue}
-                      onChange={(event) =>
-                        setManthValue(Number(event.target.value))
-                      }
-                      displayEmpty
-                      inputProps={{ 'aria-label': 'Without label' }}
-                      size="small"
-                    >
-                      <MenuItem value="">
-                        <em>月を選択</em>
-                      </MenuItem>
-                      <MenuItem value={1}>1月</MenuItem>
-                      <MenuItem value={2}>2月</MenuItem>
-                      <MenuItem value={3}>3月</MenuItem>
-                      <MenuItem value={4}>4月</MenuItem>
-                      <MenuItem value={5}>5月</MenuItem>
-                      <MenuItem value={6}>6月</MenuItem>
-                      <MenuItem value={7}>7月</MenuItem>
-                      <MenuItem value={8}>8月</MenuItem>
-                      <MenuItem value={9}>9月</MenuItem>
-                      <MenuItem value={10}>10月</MenuItem>
-                      <MenuItem value={11}>11月</MenuItem>
-                      <MenuItem value={12}>12月</MenuItem>
-                    </Select>
-                  </Grid>
-                  <Grid item xs={5} sx={{ textAlign: 'center' }}>
-                    <Button size="medium" variant="contained">
-                      表示
-                    </Button>
-                  </Grid>
-                </Grid>
-              </Stack>
-            </Container>
-          );
+          return <OverView billingData={billingData} />;
         } else if (tabValue === '1') {
           return (
             <Container

--- a/react-front/src/components/user/billing/Billing.tsx
+++ b/react-front/src/components/user/billing/Billing.tsx
@@ -5,8 +5,10 @@ import Paper from '@mui/material/Paper';
 import { Container, Stack, Tab, Tabs, Typography } from '@mui/material';
 
 import { BillingData } from '../../types/BillingData';
+
 import { OverView } from './tab-contents/OverView';
 import { CarryOver } from './tab-contents/CarryOver';
+import { Chat } from './tab-contents/Chat';
 
 export const NextBilling = () => {
   const [billingData, setBillingData] = useState<BillingData>({
@@ -131,7 +133,7 @@ export const NextBilling = () => {
         } else if (tabValue === '1') {
           return <CarryOver billingData={billingData} />;
         } else if (tabValue === '2') {
-          return <h1>３個目</h1>;
+          return <Chat />;
         } else {
           return <h1>対応していないタブ値です。</h1>;
         }

--- a/react-front/src/components/user/billing/Billing.tsx
+++ b/react-front/src/components/user/billing/Billing.tsx
@@ -130,8 +130,10 @@ export const NextBilling = () => {
           return <OverView billingData={billingData} />;
         } else if (tabValue === '1') {
           return <CarryOver billingData={billingData} />;
-        } else {
+        } else if (tabValue === '2') {
           return <h1>３個目</h1>;
+        } else {
+          return <h1>対応していないタブ値です。</h1>;
         }
       })()}
     </Container>

--- a/react-front/src/components/user/billing/Billing.tsx
+++ b/react-front/src/components/user/billing/Billing.tsx
@@ -17,9 +17,7 @@ import {
   Stack,
   Tab,
   Tabs,
-  ThemeProvider,
   Typography,
-  createTheme,
 } from '@mui/material';
 
 import { BillingData } from '../../types/BillingData';
@@ -103,34 +101,23 @@ export const NextBilling = () => {
         setBillingData(billingDataSrc);
     }, []);*/
 
-  const userTabTheme = createTheme({
-    palette: {
-      mode: 'light',
-      primary: {
-        main: '#26c988',
-      },
-    },
-  });
-
   return (
     <Container sx={{ height: '100%', overflowY: 'scroll' }}>
-      <ThemeProvider theme={userTabTheme}>
-        <Container sx={{ width: '80%' }}>
-          <Tabs
-            value={tabValue}
-            onChange={(event: React.BaseSyntheticEvent, newValue: string) =>
-              setTabValue(newValue)
-            }
-            textColor="primary"
-            indicatorColor="primary"
-            aria-label="secondary tabs example"
-          >
-            <Tab value="0" label="確認" />
-            <Tab value="1" label="繰越" />
-            <Tab value="2" label="チャット" />
-          </Tabs>
-        </Container>
-      </ThemeProvider>
+      <Container sx={{ width: '80%' }}>
+        <Tabs
+          value={tabValue}
+          onChange={(event: React.BaseSyntheticEvent, newValue: string) =>
+            setTabValue(newValue)
+          }
+          textColor="primary"
+          indicatorColor="primary"
+          aria-label="secondary tabs example"
+        >
+          <Tab value="0" label="確認" />
+          <Tab value="1" label="繰越" />
+          <Tab value="2" label="チャット" />
+        </Tabs>
+      </Container>
 
       <Paper
         elevation={3}

--- a/react-front/src/components/user/billing/Billing.tsx
+++ b/react-front/src/components/user/billing/Billing.tsx
@@ -2,16 +2,11 @@ import { useEffect, useState } from 'react';
 
 import Paper from '@mui/material/Paper';
 
-import Radio from '@mui/material/Radio';
-import RadioGroup from '@mui/material/RadioGroup';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import FormControl from '@mui/material/FormControl';
-
-import { PaymentOption } from './PaymentOption';
 import { Container, Stack, Tab, Tabs, Typography } from '@mui/material';
 
 import { BillingData } from '../../types/BillingData';
 import { OverView } from './tab-contents/OverView';
+import { CarryOver } from './tab-contents/CarryOver';
 
 export const NextBilling = () => {
   const [billingData, setBillingData] = useState<BillingData>({
@@ -26,7 +21,6 @@ export const NextBilling = () => {
     paidPrice: 0,
     paid: 0,
   });
-  const [value, setValue] = useState<string>('no');
 
   const [tabValue, setTabValue] = useState<string>('0');
 
@@ -135,49 +129,7 @@ export const NextBilling = () => {
         if (tabValue === '0') {
           return <OverView billingData={billingData} />;
         } else if (tabValue === '1') {
-          return (
-            <Container
-              sx={{
-                width: '90%',
-                textAlign: 'center',
-                marginTop: '20px',
-                marginBottom: '50px',
-              }}
-            >
-              <Typography variant="h5">繰越のタイプを選択</Typography>
-              <FormControl>
-                <RadioGroup
-                  row
-                  aria-labelledby="demo-radio-buttons-group-label"
-                  value={value}
-                  name="radio-buttons-group"
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                    setValue(e.target.value)
-                  }
-                >
-                  <FormControlLabel
-                    value="no"
-                    control={<Radio />}
-                    label="繰越なし"
-                  />
-                  <FormControlLabel
-                    value="part"
-                    control={<Radio />}
-                    label="一部繰越"
-                  />
-                  <FormControlLabel
-                    value="all"
-                    control={<Radio />}
-                    label="全額繰越"
-                  />
-                </RadioGroup>
-                <PaymentOption
-                  billingData={billingData}
-                  carryOverType={value}
-                />
-              </FormControl>
-            </Container>
-          );
+          return <CarryOver billingData={billingData} />;
         } else {
           return <h1>３個目</h1>;
         }

--- a/react-front/src/components/user/billing/PaymentOption.tsx
+++ b/react-front/src/components/user/billing/PaymentOption.tsx
@@ -84,6 +84,8 @@ export const PaymentOption = (props: Props) => {
     }
   };
 
+  //TODO: 最初の段階でも以下の条件を確認する
+
   useEffect(() => {
     setCarryOverPrice(
       billingData.price + billingData.beforeCarryOver - paymentPrice,

--- a/react-front/src/components/user/billing/PaymentOption.tsx
+++ b/react-front/src/components/user/billing/PaymentOption.tsx
@@ -192,7 +192,7 @@ export const PaymentOption = (props: Props) => {
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button onClick={dialogClose} autoFocus variant="contained">
+            <Button onClick={dialogClose} autoFocus>
               閉じる
             </Button>
           </DialogActions>
@@ -274,7 +274,7 @@ export const PaymentOption = (props: Props) => {
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button onClick={dialogClose} autoFocus variant="contained">
+            <Button onClick={dialogClose} autoFocus>
               閉じる
             </Button>
           </DialogActions>

--- a/react-front/src/components/user/billing/PaymentOption.tsx
+++ b/react-front/src/components/user/billing/PaymentOption.tsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   Container,
   Dialog,
   DialogActions,
@@ -7,9 +6,11 @@ import {
   DialogContentText,
   DialogTitle,
   Stack,
-  TextField,
   Typography,
 } from '@mui/material';
+
+import { Button, Input } from '@mui/joy';
+
 import { useEffect, useState } from 'react';
 
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
@@ -138,7 +139,7 @@ export const PaymentOption = (props: Props) => {
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button onClick={dialogClose} autoFocus variant="contained">
+            <Button onClick={dialogClose} autoFocus>
               閉じる
             </Button>
           </DialogActions>
@@ -157,8 +158,6 @@ export const PaymentOption = (props: Props) => {
         </Typography>
         <Stack spacing={2}>
           <Button
-            size="small"
-            variant="contained"
             onClick={() => updateBillingData('no', 0)}
             disabled={saveDisabled}
           >
@@ -212,11 +211,9 @@ export const PaymentOption = (props: Props) => {
         </Typography>
         <Stack spacing={1}>
           <Typography variant="h6">今月支払う金額を入力</Typography>
-          <TextField
-            id="user-id"
+          <Input
             onChange={(event) => setPaymentPrice(Number(event.target.value))}
             value={paymentPrice}
-            variant="outlined"
           />
           <Typography variant="h3">
             <ArrowDownwardIcon fontSize="large" />
@@ -243,8 +240,6 @@ export const PaymentOption = (props: Props) => {
             }
           })()}
           <Button
-            size="small"
-            variant="contained"
             onClick={() => updateBillingData('part', carryOverPrice)}
             disabled={saveDisabled}
           >
@@ -298,8 +293,6 @@ export const PaymentOption = (props: Props) => {
         </Typography>
         <Stack spacing={2}>
           <Button
-            size="small"
-            variant="contained"
             onClick={() =>
               updateBillingData(
                 'all',

--- a/react-front/src/components/user/billing/tab-contents/CarryOver.tsx
+++ b/react-front/src/components/user/billing/tab-contents/CarryOver.tsx
@@ -10,6 +10,7 @@ import { useState } from 'react';
 
 import { BillingData } from '../../../types/BillingData';
 import { PaymentOption } from './PaymentOption';
+import { Button } from '@mui/joy';
 
 type Props = {
   billingData: BillingData;
@@ -55,6 +56,7 @@ export const CarryOver = (props: Props) => {
             />
           </RadioGroup>
         </FormControl>
+        <Button onClick={() => setSelectPageIsShow(false)}>次へ</Button>
       </Container>
     );
   } else {
@@ -67,7 +69,11 @@ export const CarryOver = (props: Props) => {
           marginBottom: '50px',
         }}
       >
-        <PaymentOption billingData={billingData} carryOverType={value} />
+        <PaymentOption
+          billingData={billingData}
+          carryOverType={value}
+          setSelectPageIsShow={setSelectPageIsShow}
+        />
       </Container>
     );
   }

--- a/react-front/src/components/user/billing/tab-contents/CarryOver.tsx
+++ b/react-front/src/components/user/billing/tab-contents/CarryOver.tsx
@@ -21,7 +21,7 @@ export const CarryOver = (props: Props) => {
   const [selectPageIsShow, setSelectPageIsShow] = useState<boolean>(true);
 
   const optionList: OptionList[] = [
-    { optionValue: 'no', optionLabel: '設定なし' },
+    { optionValue: 'no', optionLabel: '繰越しない' },
     { optionValue: 'part', optionLabel: '一部繰越' },
     { optionValue: 'all', optionLabel: '全額繰越' },
   ];

--- a/react-front/src/components/user/billing/tab-contents/CarryOver.tsx
+++ b/react-front/src/components/user/billing/tab-contents/CarryOver.tsx
@@ -19,32 +19,56 @@ export const CarryOver = (props: Props) => {
   const billingData = props.billingData;
   const [value, setValue] = useState<string>('no');
 
-  return (
-    <Container
-      sx={{
-        width: '90%',
-        textAlign: 'center',
-        marginTop: '20px',
-        marginBottom: '50px',
-      }}
-    >
-      <Typography variant="h5">繰越のタイプを選択</Typography>
-      <FormControl>
-        <RadioGroup
-          row
-          aria-labelledby="demo-radio-buttons-group-label"
-          value={value}
-          name="radio-buttons-group"
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-            setValue(e.target.value)
-          }
-        >
-          <FormControlLabel value="no" control={<Radio />} label="繰越なし" />
-          <FormControlLabel value="part" control={<Radio />} label="一部繰越" />
-          <FormControlLabel value="all" control={<Radio />} label="全額繰越" />
-        </RadioGroup>
+  const [selectPageIsShow, setSelectPageIsShow] = useState<boolean>(true);
+
+  if (selectPageIsShow) {
+    return (
+      <Container
+        sx={{
+          width: '90%',
+          textAlign: 'center',
+          marginTop: '20px',
+          marginBottom: '50px',
+        }}
+      >
+        <Typography variant="h5">繰越のタイプを選択</Typography>
+        <FormControl>
+          <RadioGroup
+            row
+            aria-labelledby="demo-radio-buttons-group-label"
+            value={value}
+            name="radio-buttons-group"
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setValue(e.target.value)
+            }
+          >
+            <FormControlLabel value="no" control={<Radio />} label="繰越なし" />
+            <FormControlLabel
+              value="part"
+              control={<Radio />}
+              label="一部繰越"
+            />
+            <FormControlLabel
+              value="all"
+              control={<Radio />}
+              label="全額繰越"
+            />
+          </RadioGroup>
+        </FormControl>
+      </Container>
+    );
+  } else {
+    return (
+      <Container
+        sx={{
+          width: '90%',
+          textAlign: 'center',
+          marginTop: '20px',
+          marginBottom: '50px',
+        }}
+      >
         <PaymentOption billingData={billingData} carryOverType={value} />
-      </FormControl>
-    </Container>
-  );
+      </Container>
+    );
+  }
 };

--- a/react-front/src/components/user/billing/tab-contents/CarryOver.tsx
+++ b/react-front/src/components/user/billing/tab-contents/CarryOver.tsx
@@ -1,3 +1,50 @@
-export const CarryOver = () => {
-  return <h1>繰越</h1>;
+import {
+  Container,
+  FormControl,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
+  Typography,
+} from '@mui/material';
+import { useState } from 'react';
+
+import { BillingData } from '../../../types/BillingData';
+import { PaymentOption } from './PaymentOption';
+
+type Props = {
+  billingData: BillingData;
+};
+
+export const CarryOver = (props: Props) => {
+  const billingData = props.billingData;
+  const [value, setValue] = useState<string>('no');
+
+  return (
+    <Container
+      sx={{
+        width: '90%',
+        textAlign: 'center',
+        marginTop: '20px',
+        marginBottom: '50px',
+      }}
+    >
+      <Typography variant="h5">繰越のタイプを選択</Typography>
+      <FormControl>
+        <RadioGroup
+          row
+          aria-labelledby="demo-radio-buttons-group-label"
+          value={value}
+          name="radio-buttons-group"
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setValue(e.target.value)
+          }
+        >
+          <FormControlLabel value="no" control={<Radio />} label="繰越なし" />
+          <FormControlLabel value="part" control={<Radio />} label="一部繰越" />
+          <FormControlLabel value="all" control={<Radio />} label="全額繰越" />
+        </RadioGroup>
+        <PaymentOption billingData={billingData} carryOverType={value} />
+      </FormControl>
+    </Container>
+  );
 };

--- a/react-front/src/components/user/billing/tab-contents/CarryOver.tsx
+++ b/react-front/src/components/user/billing/tab-contents/CarryOver.tsx
@@ -1,0 +1,3 @@
+export const CarryOver = () => {
+  return <h1>繰越</h1>;
+};

--- a/react-front/src/components/user/billing/tab-contents/CarryOver.tsx
+++ b/react-front/src/components/user/billing/tab-contents/CarryOver.tsx
@@ -1,16 +1,9 @@
-import {
-  Container,
-  FormControl,
-  FormControlLabel,
-  Radio,
-  RadioGroup,
-  Typography,
-} from '@mui/material';
+import { Container, Typography } from '@mui/material';
 import { useState } from 'react';
 
 import { BillingData } from '../../../types/BillingData';
 import { PaymentOption } from './PaymentOption';
-import { Button } from '@mui/joy';
+import { Button, Radio, RadioGroup, Sheet } from '@mui/joy';
 
 type Props = {
   billingData: BillingData;
@@ -33,29 +26,54 @@ export const CarryOver = (props: Props) => {
         }}
       >
         <Typography variant="h5">繰越のタイプを選択</Typography>
-        <FormControl>
+
+        <Container sx={{ maxWidth: '80%', margin: '20px auto 20px auto' }}>
           <RadioGroup
-            row
-            aria-labelledby="demo-radio-buttons-group-label"
-            value={value}
-            name="radio-buttons-group"
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              setValue(e.target.value)
-            }
+            aria-labelledby="storage-label"
+            defaultValue="512GB"
+            size="lg"
+            sx={{ gap: 1.5 }}
           >
-            <FormControlLabel value="no" control={<Radio />} label="繰越なし" />
-            <FormControlLabel
-              value="part"
-              control={<Radio />}
-              label="一部繰越"
-            />
-            <FormControlLabel
-              value="all"
-              control={<Radio />}
-              label="全額繰越"
-            />
+            {['512GB', '1TB', '2TB'].map((value) => (
+              <Sheet
+                key={value}
+                sx={{
+                  p: 2,
+                  borderRadius: 'md',
+                  boxShadow: 'sm',
+                }}
+              >
+                <Radio
+                  label={`${value} SSD storage`}
+                  overlay
+                  disableIcon
+                  value={value}
+                  slotProps={{
+                    label: ({ checked }) => ({
+                      sx: {
+                        fontWeight: 'lg',
+                        fontSize: 'md',
+                        color: checked ? 'text.primary' : 'text.secondary',
+                      },
+                    }),
+                    action: ({ checked }) => ({
+                      sx: (theme) => ({
+                        ...(checked && {
+                          '--variant-borderWidth': '2px',
+                          '&&': {
+                            // && to increase the specificity to win the base :hover styles
+                            borderColor: theme.vars.palette.primary[500],
+                          },
+                        }),
+                      }),
+                    }),
+                  }}
+                />
+              </Sheet>
+            ))}
           </RadioGroup>
-        </FormControl>
+        </Container>
+
         <Button onClick={() => setSelectPageIsShow(false)}>次へ</Button>
       </Container>
     );

--- a/react-front/src/components/user/billing/tab-contents/CarryOver.tsx
+++ b/react-front/src/components/user/billing/tab-contents/CarryOver.tsx
@@ -3,17 +3,28 @@ import { useState } from 'react';
 
 import { BillingData } from '../../../types/BillingData';
 import { PaymentOption } from './PaymentOption';
-import { Button, Radio, RadioGroup, Sheet } from '@mui/joy';
+import { Button, Radio, RadioGroup, Sheet, Stack } from '@mui/joy';
 
 type Props = {
   billingData: BillingData;
 };
+
+interface OptionList {
+  optionValue: string;
+  optionLabel: string;
+}
 
 export const CarryOver = (props: Props) => {
   const billingData = props.billingData;
   const [value, setValue] = useState<string>('no');
 
   const [selectPageIsShow, setSelectPageIsShow] = useState<boolean>(true);
+
+  const optionList: OptionList[] = [
+    { optionValue: 'no', optionLabel: '設定なし' },
+    { optionValue: 'part', optionLabel: '一部繰越' },
+    { optionValue: 'all', optionLabel: '全額繰越' },
+  ];
 
   if (selectPageIsShow) {
     return (
@@ -26,7 +37,6 @@ export const CarryOver = (props: Props) => {
         }}
       >
         <Typography variant="h5">繰越のタイプを選択</Typography>
-
         <Container sx={{ maxWidth: '80%', margin: '20px auto 20px auto' }}>
           <RadioGroup
             aria-labelledby="storage-label"
@@ -34,9 +44,9 @@ export const CarryOver = (props: Props) => {
             size="lg"
             sx={{ gap: 1.5 }}
           >
-            {['512GB', '1TB', '2TB'].map((value) => (
+            {optionList.map((value) => (
               <Sheet
-                key={value}
+                key={value.optionValue}
                 sx={{
                   p: 2,
                   borderRadius: 'md',
@@ -44,10 +54,13 @@ export const CarryOver = (props: Props) => {
                 }}
               >
                 <Radio
-                  label={`${value} SSD storage`}
+                  label={value.optionLabel}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setValue(e.target.value)
+                  }
                   overlay
                   disableIcon
-                  value={value}
+                  value={value.optionValue}
                   slotProps={{
                     label: ({ checked }) => ({
                       sx: {
@@ -74,7 +87,9 @@ export const CarryOver = (props: Props) => {
           </RadioGroup>
         </Container>
 
-        <Button onClick={() => setSelectPageIsShow(false)}>次へ</Button>
+        <Stack spacing={1}>
+          <Button onClick={() => setSelectPageIsShow(false)}>次へ</Button>
+        </Stack>
       </Container>
     );
   } else {

--- a/react-front/src/components/user/billing/tab-contents/Chat.tsx
+++ b/react-front/src/components/user/billing/tab-contents/Chat.tsx
@@ -1,0 +1,3 @@
+export const Chat = () => {
+  return <h1>チャット</h1>;
+};

--- a/react-front/src/components/user/billing/tab-contents/OverView.tsx
+++ b/react-front/src/components/user/billing/tab-contents/OverView.tsx
@@ -1,3 +1,144 @@
-export const OverView = () => {
-  return <h1>確認</h1>;
+import {
+  Button,
+  Container,
+  Grid,
+  MenuItem,
+  Select,
+  Stack,
+  Typography,
+} from '@mui/material';
+
+import { BillingData } from '../../../types/BillingData';
+import { useState } from 'react';
+
+import PublicIcon from '@mui/icons-material/Public';
+
+type Props = {
+  billingData: BillingData;
+};
+
+export const OverView = (props: Props) => {
+  const billingData = props.billingData;
+
+  const comparePrice = -1000;
+  const compareCo2 = -30;
+
+  const [yearValue, setYearValue] = useState<number | string>('');
+  const [manthValue, setManthValue] = useState<number | string>('');
+
+  return (
+    <Container sx={{ width: '80%', marginBottom: '50px' }}>
+      <Grid container spacing={1}>
+        <Grid item xs={6} sx={{ textAlign: 'center' }}>
+          <Stack spacing={0.5} sx={{ paddingTop: '20px', textAlign: 'center' }}>
+            <Typography variant="body1">使用量</Typography>
+            <Typography variant="h4">{billingData.useAmount} kWh</Typography>
+          </Stack>
+        </Grid>
+        <Grid item xs={6} sx={{ textAlign: 'center' }}>
+          <Stack spacing={0.5} sx={{ paddingTop: '20px', textAlign: 'center' }}>
+            <Typography variant="body1">〜先月 繰越額</Typography>
+            <Typography variant="h4">
+              ￥{billingData.beforeCarryOver}
+            </Typography>
+          </Stack>
+        </Grid>
+        <Grid item xs={6} sx={{ textAlign: 'center' }}>
+          <Stack spacing={0.5} sx={{ paddingTop: '20px', textAlign: 'center' }}>
+            <Typography variant="body1">請求額</Typography>
+            <Typography variant="h4">￥{billingData.price}</Typography>
+          </Stack>
+        </Grid>
+        <Grid item xs={6} sx={{ textAlign: 'center' }}>
+          <Stack spacing={0.5} sx={{ paddingTop: '20px', textAlign: 'center' }}>
+            <Typography variant="body1">今月 繰越額(予定)</Typography>
+            <Typography variant="h4">￥{billingData.carryOverPrice}</Typography>
+          </Stack>
+        </Grid>
+        <Grid item xs={6} sx={{ textAlign: 'center' }}>
+          <Stack spacing={0.5} sx={{ paddingTop: '20px', textAlign: 'center' }}>
+            <Typography variant="body1" sx={{ fontWeight: 'bold' }}>
+              先月 請求額比較
+            </Typography>
+            {comparePrice <= 0 ? (
+              <Typography variant="h4" sx={{ color: 'success.main' }}>
+                ￥{comparePrice}
+              </Typography>
+            ) : (
+              <Typography variant="h4" sx={{ color: 'error.main' }}>
+                ￥{comparePrice}
+              </Typography>
+            )}
+          </Stack>
+        </Grid>
+        <Grid item xs={6} sx={{ textAlign: 'center' }}>
+          <Stack spacing={0.5} sx={{ paddingTop: '20px', textAlign: 'center' }}>
+            <Typography variant="body1" sx={{ fontWeight: 'bold' }}>
+              先月 CO2削減量
+            </Typography>
+            {compareCo2 <= 0 ? (
+              <Typography variant="h4" sx={{ color: 'success.main' }}>
+                <PublicIcon fontSize="large" />
+                {compareCo2}kg
+              </Typography>
+            ) : (
+              <Typography variant="h4" sx={{ color: 'error.main' }}>
+                {compareCo2}kg
+              </Typography>
+            )}
+          </Stack>
+        </Grid>
+      </Grid>
+      <Stack spacing={0.5} sx={{ marginTop: '30px' }}>
+        <Typography variant="h5">表示する年・月を選択</Typography>
+        <Grid container spacing={2}>
+          <Grid item xs={4} sx={{ textAlign: 'center' }}>
+            <Select
+              value={yearValue}
+              onChange={(event) => setYearValue(Number(event.target.value))}
+              displayEmpty
+              inputProps={{ 'aria-label': 'Without label' }}
+              size="small"
+            >
+              <MenuItem value="">
+                <em>年を選択</em>
+              </MenuItem>
+              <MenuItem value={2022}>2022年</MenuItem>
+              <MenuItem value={2023}>2023年</MenuItem>
+            </Select>
+          </Grid>
+          <Grid item xs={3} sx={{ textAlign: 'center' }}>
+            <Select
+              value={manthValue}
+              onChange={(event) => setManthValue(Number(event.target.value))}
+              displayEmpty
+              inputProps={{ 'aria-label': 'Without label' }}
+              size="small"
+            >
+              <MenuItem value="">
+                <em>月を選択</em>
+              </MenuItem>
+              <MenuItem value={1}>1月</MenuItem>
+              <MenuItem value={2}>2月</MenuItem>
+              <MenuItem value={3}>3月</MenuItem>
+              <MenuItem value={4}>4月</MenuItem>
+              <MenuItem value={5}>5月</MenuItem>
+              <MenuItem value={6}>6月</MenuItem>
+              <MenuItem value={7}>7月</MenuItem>
+              <MenuItem value={8}>8月</MenuItem>
+              <MenuItem value={9}>9月</MenuItem>
+              <MenuItem value={10}>10月</MenuItem>
+              <MenuItem value={11}>11月</MenuItem>
+              <MenuItem value={12}>12月</MenuItem>
+            </Select>
+          </Grid>
+          <Grid item xs={5} sx={{ textAlign: 'center' }}>
+            <Button size="medium" variant="contained">
+              表示
+            </Button>
+          </Grid>
+        </Grid>
+      </Stack>
+    </Container>
+  );
 };

--- a/react-front/src/components/user/billing/tab-contents/OverView.tsx
+++ b/react-front/src/components/user/billing/tab-contents/OverView.tsx
@@ -1,0 +1,3 @@
+export const OverView = () => {
+  return <h1>確認</h1>;
+};

--- a/react-front/src/components/user/billing/tab-contents/OverView.tsx
+++ b/react-front/src/components/user/billing/tab-contents/OverView.tsx
@@ -26,6 +26,9 @@ export const OverView = (props: Props) => {
   const [yearValue, setYearValue] = useState<number | string>('');
   const [manthValue, setManthValue] = useState<number | string>('');
 
+  const yearList: number[] = [2022, 2023];
+  const manthList: number[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+
   return (
     <Container sx={{ width: '80%', marginBottom: '50px' }}>
       <Grid container spacing={1}>
@@ -103,8 +106,9 @@ export const OverView = (props: Props) => {
               <MenuItem value="">
                 <em>年を選択</em>
               </MenuItem>
-              <MenuItem value={2022}>2022年</MenuItem>
-              <MenuItem value={2023}>2023年</MenuItem>
+              {yearList.map((year) => (
+                <MenuItem value={year}>{year}年</MenuItem>
+              ))}
             </Select>
           </Grid>
           <Grid item xs={3} sx={{ textAlign: 'center' }}>
@@ -118,18 +122,9 @@ export const OverView = (props: Props) => {
               <MenuItem value="">
                 <em>月を選択</em>
               </MenuItem>
-              <MenuItem value={1}>1月</MenuItem>
-              <MenuItem value={2}>2月</MenuItem>
-              <MenuItem value={3}>3月</MenuItem>
-              <MenuItem value={4}>4月</MenuItem>
-              <MenuItem value={5}>5月</MenuItem>
-              <MenuItem value={6}>6月</MenuItem>
-              <MenuItem value={7}>7月</MenuItem>
-              <MenuItem value={8}>8月</MenuItem>
-              <MenuItem value={9}>9月</MenuItem>
-              <MenuItem value={10}>10月</MenuItem>
-              <MenuItem value={11}>11月</MenuItem>
-              <MenuItem value={12}>12月</MenuItem>
+              {manthList.map((manth) => (
+                <MenuItem value={manth}>{manth}月</MenuItem>
+              ))}
             </Select>
           </Grid>
           <Grid item xs={5} sx={{ textAlign: 'center' }}>

--- a/react-front/src/components/user/billing/tab-contents/PaymentOption.tsx
+++ b/react-front/src/components/user/billing/tab-contents/PaymentOption.tsx
@@ -22,11 +22,13 @@ import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 type Props = {
   billingData: BillingData;
   carryOverType: string;
+  setSelectPageIsShow: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export const PaymentOption = (props: Props) => {
   const billingData: BillingData = props.billingData;
   const carryOverType: string = props.carryOverType;
+  const setSelectPageIsShow = props.setSelectPageIsShow;
 
   //一部繰越で、今月支払う金額
   const [paymentPrice, setPaymentPrice] = useState<number>(
@@ -46,6 +48,11 @@ export const PaymentOption = (props: Props) => {
 
   const dialogClose = () => {
     setDialogOpen(false);
+    backPage();
+  };
+
+  const backPage = () => {
+    setSelectPageIsShow(true);
   };
 
   //請求データを更新する関数
@@ -165,6 +172,9 @@ export const PaymentOption = (props: Props) => {
           >
             設定を保存
           </Button>
+          <Button variant="outlined" onClick={() => backPage()}>
+            選択に戻る
+          </Button>
         </Stack>
       </div>
     );
@@ -247,6 +257,9 @@ export const PaymentOption = (props: Props) => {
           >
             設定を保存
           </Button>
+          <Button variant="outlined" onClick={() => backPage()}>
+            選択に戻る
+          </Button>
         </Stack>
       </div>
     );
@@ -304,6 +317,9 @@ export const PaymentOption = (props: Props) => {
             disabled={saveDisabled}
           >
             設定を保存
+          </Button>
+          <Button variant="outlined" onClick={() => backPage()}>
+            選択に戻る
           </Button>
         </Stack>
       </div>

--- a/react-front/src/components/user/billing/tab-contents/PaymentOption.tsx
+++ b/react-front/src/components/user/billing/tab-contents/PaymentOption.tsx
@@ -15,7 +15,7 @@ import { useEffect, useState } from 'react';
 
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 
-import { BillingData } from '../../types/BillingData';
+import { BillingData } from '../../../types/BillingData';
 
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 

--- a/react-front/src/components/user/billing/tab-contents/PaymentOption.tsx
+++ b/react-front/src/components/user/billing/tab-contents/PaymentOption.tsx
@@ -158,9 +158,8 @@ export const PaymentOption = (props: Props) => {
           sx={{
             marginBottom: '20px',
             color: '#000',
-            background: '#ededed',
             fontWeight: 'bold',
-            textAlign: 'left',
+            textAlign: 'center',
           }}
         >
           繰越設定は行わず、全額を支払います。
@@ -214,9 +213,8 @@ export const PaymentOption = (props: Props) => {
           sx={{
             marginBottom: '20px',
             color: '#000',
-            background: '#ededed',
             fontWeight: 'bold',
-            textAlign: 'left',
+            textAlign: 'center',
           }}
         >
           一部を繰越し、今月の支払額を設定します。
@@ -299,9 +297,8 @@ export const PaymentOption = (props: Props) => {
           sx={{
             marginBottom: '20px',
             color: '#000',
-            background: '#ededed',
             fontWeight: 'bold',
-            textAlign: 'left',
+            textAlign: 'center',
           }}
         >
           全額を繰越し、今月は支払いを行いません。


### PR DESCRIPTION
# 変更
* joy uiをインストールした。
* 以下の画面のデザインを変更した。
　* ユーザー側と管理者側のログイン画面
　* 繰越画面の繰越タイプ選択と、入力画面
* 繰越設定の画面をいくつかにコンポーネント化した。
* 年と月の選択肢の構成に、map関数を使うようにした。
* 請求データを格納するグローバルステートを定義した。

# issue
closed #51 